### PR TITLE
Basic Service Announcements

### DIFF
--- a/app/assets/javascripts/admin/templates/service_announcements/delete.jst.ejs
+++ b/app/assets/javascripts/admin/templates/service_announcements/delete.jst.ejs
@@ -1,0 +1,27 @@
+<div class="ui basic modal">
+  <div class="ui icon header">
+    <i class="trash icon"></i>
+    Delete Service Announcement?
+  </div>
+  <div class="content">
+    <p>Are you sure you want to delete this Service Announcement?</p>
+    <table class="table">
+      <tbody>
+        <tr>
+          <td>Title</td>
+          <td><%= title %></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <div class="actions">
+    <div class="ui green basic cancel inverted button">
+      <i class="remove icon"></i>
+      Cancel!
+    </div>
+    <a href="<%= url %>" data-method="delete" rel="nofollow" class="ui red ok inverted button">
+      <i class="checkmark icon"></i>
+      Yes, I'm sure
+    </a>
+  </div>
+</div>

--- a/app/assets/javascripts/common.js
+++ b/app/assets/javascripts/common.js
@@ -35,6 +35,9 @@ document.addEventListener("turbolinks:load", () => {
 
   // Handle making the side menus sticky
   $("[data-behavior~=sticky]").each((idx, element) => {
+    if($(element.dataset.context).length < 1)
+      return
+
     let stickySettings = Object.assign({}, element.dataset)
     if(stickySettings.offset)
       stickySettings.offset = parseInt(stickySettings.offset)

--- a/app/controllers/admin/service_announcements/toggle_controller.rb
+++ b/app/controllers/admin/service_announcements/toggle_controller.rb
@@ -15,6 +15,6 @@ class Admin::ServiceAnnouncements::ToggleController < AdminController
   private
 
   def set_service_announcement
-    @service_announcement = ServiceAnnouncement.unscoped.find params[:service_announcement_id]
+    @service_announcement = ServiceAnnouncement.find params[:service_announcement_id]
   end
 end

--- a/app/controllers/admin/service_announcements/toggle_controller.rb
+++ b/app/controllers/admin/service_announcements/toggle_controller.rb
@@ -15,6 +15,6 @@ class Admin::ServiceAnnouncements::ToggleController < AdminController
   private
 
   def set_service_announcement
-    @service_announcement = ServiceAnnouncement.find params[:service_announcement_id]
+    @service_announcement = ServiceAnnouncement.unscoped.find params[:service_announcement_id]
   end
 end

--- a/app/controllers/admin/service_announcements/toggle_controller.rb
+++ b/app/controllers/admin/service_announcements/toggle_controller.rb
@@ -1,0 +1,20 @@
+class Admin::ServiceAnnouncements::ToggleController < AdminController
+  before_action :set_service_announcement
+
+  # POST /admin/service_announcements/1/toggle
+  def create
+    respond_to do |format|
+      if @service_announcement.update active: !@service_announcement.active
+        format.html { redirect_to admin_service_announcement_path(@service_announcement), notice: "Active Toggled" }
+      else
+        format.html { render "admin/service_announcements/show" }
+      end
+    end
+  end
+
+  private
+
+  def set_service_announcement
+    @service_announcement = ServiceAnnouncement.find params[:service_announcement_id]
+  end
+end

--- a/app/controllers/admin/service_announcements_controller.rb
+++ b/app/controllers/admin/service_announcements_controller.rb
@@ -4,7 +4,7 @@ class Admin::ServiceAnnouncementsController < AdminController
 
   # GET /service_announcements
   def index
-    @service_announcements = ServiceAnnouncement.unscoped.all.order(created_at: :desc).page params[:page]
+    @service_announcements = ServiceAnnouncement.all.order(created_at: :desc).page params[:page]
   end
 
   # GET /service_announcements/1
@@ -58,11 +58,11 @@ class Admin::ServiceAnnouncementsController < AdminController
   private
 
   def set_service_announcement
-    @service_announcement = ServiceAnnouncement.unscoped.find params[:id]
+    @service_announcement = ServiceAnnouncement.find params[:id]
   end
 
   def set_count
-    @count = ServiceAnnouncement.count
+    @count = ServiceAnnouncement.displayable.count
   end
 
   def service_announcement_params

--- a/app/controllers/admin/service_announcements_controller.rb
+++ b/app/controllers/admin/service_announcements_controller.rb
@@ -1,2 +1,71 @@
 class Admin::ServiceAnnouncementsController < AdminController
+  before_action :set_count
+  before_action :set_service_announcement, only: [:show, :edit, :update, :destroy]
+
+  # GET /service_announcements
+  def index
+    @service_announcements = ServiceAnnouncement.unscoped.all.order(created_at: :desc).page params[:page]
+  end
+
+  # GET /service_announcements/1
+  def show
+  end
+
+  # GET /service_announcements/new
+  def new
+    @service_announcement = ServiceAnnouncement.new
+  end
+
+  # POST /service_announcements
+  def create
+    @service_announcement = ServiceAnnouncement.new service_announcement_params
+
+    respond_to do |format|
+      if @service_announcement.save
+        format.html { redirect_to [:admin, @service_announcement], notice: "Service Announcement was successfully created." }
+      else
+        format.html { render :new }
+      end
+    end
+  end
+
+  # GET /service_announcements/1/edit
+  def edit
+  end
+
+  # PATCH/PUT /service_announcements/1
+  def update
+    respond_to do |format|
+      if @service_announcement.update(service_announcement_params)
+        format.html { redirect_to [:admin, @service_announcement], notice: "Service Announcement was successfully updated." }
+      else
+        format.html { render :edit }
+      end
+    end
+  end
+
+  # DELETE /service_announcements/1
+  def destroy
+    respond_to do |format|
+      if @service_announcement.destroy
+        format.html { redirect_to admin_service_announcements_url, notice: "Service Announcement was successfully deleted." }
+      else
+        format.html { render :new }
+      end
+    end
+  end
+
+  private
+
+  def set_service_announcement
+    @service_announcement = ServiceAnnouncement.unscoped.find params[:id]
+  end
+
+  def set_count
+    @count = ServiceAnnouncement.count
+  end
+
+  def service_announcement_params
+    params.require(:service_announcement).permit(:title, :message, :color, :icon, :start_at, :end_at, :active)
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,11 +3,13 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery with: :exception
 
+  before_action :set_active_service_announcements
+
+  helper_method :current_user, :signed_in?
+
   def self.require_login! **opts
     before_action :require_login, **opts
   end
-
-  helper_method :current_user, :signed_in?
 
   protected
 
@@ -26,5 +28,9 @@ class ApplicationController < ActionController::Base
   def current_user= user
     @current_user = user
     session[:user_id] = user&.id
+  end
+
+  def set_active_service_announcements
+    @active_service_announcements = ServiceAnnouncement.active
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,8 +3,6 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery with: :exception
 
-  before_action :set_active_service_announcements
-
   helper_method :current_user, :signed_in?
 
   def self.require_login! **opts
@@ -28,9 +26,5 @@ class ApplicationController < ActionController::Base
   def current_user= user
     @current_user = user
     session[:user_id] = user&.id
-  end
-
-  def set_active_service_announcements
-    @active_service_announcements = ServiceAnnouncement.active
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,4 +2,8 @@ module ApplicationHelper
   def auth_path provider, *args
     [ "auth", provider.to_s, args ].flatten.compact.join "/"
   end
+
+  def render_service_announcements
+    render partial: "layouts/service_announcements", locals: { service_announcements: ServiceAnnouncements.displayable }
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,6 +4,6 @@ module ApplicationHelper
   end
 
   def render_service_announcements
-    render partial: "layouts/service_announcements", locals: { service_announcements: ServiceAnnouncements.displayable }
+    render partial: "layouts/service_announcements", locals: { service_announcements: ServiceAnnouncement.displayable }
   end
 end

--- a/app/models/service_announcement.rb
+++ b/app/models/service_announcement.rb
@@ -3,10 +3,7 @@ class ServiceAnnouncement < ApplicationRecord
     in: %w( plain red orange yellow olive green teal blue violet purple pink brown grey black )
   }
 
-  default_scope { active }
-
-  def self.active
-    where("(start_at IS NULL OR start_at <= NOW()) AND (end_at IS NULL OR end_at >= NOW())")
-      .where(active: true)
-  end
+  scope :active { where(active: true) }
+  scope :current { where("(start_at IS NULL OR start_at <= NOW()) AND (end_at IS NULL OR end_at >= NOW())") }
+  scope :displayable { active.current }
 end

--- a/app/models/service_announcement.rb
+++ b/app/models/service_announcement.rb
@@ -1,2 +1,12 @@
 class ServiceAnnouncement < ApplicationRecord
+  validates :color, inclusion: {
+    in: %w( plain red orange yellow olive green teal blue violet purple pink brown grey black )
+  }
+
+  default_scope { active }
+
+  def self.active
+    where("(start_at IS NULL OR start_at <= NOW()) AND (end_at IS NULL OR end_at >= NOW())")
+      .where(active: true)
+  end
 end

--- a/app/models/service_announcement.rb
+++ b/app/models/service_announcement.rb
@@ -3,7 +3,7 @@ class ServiceAnnouncement < ApplicationRecord
     in: %w( plain red orange yellow olive green teal blue violet purple pink brown grey black )
   }
 
-  scope :active { where(active: true) }
-  scope :current { where("(start_at IS NULL OR start_at <= NOW()) AND (end_at IS NULL OR end_at >= NOW())") }
-  scope :displayable { active.current }
+  scope :active, ->{ where(active: true) }
+  scope :current, ->{ where("(start_at IS NULL OR start_at <= NOW()) AND (end_at IS NULL OR end_at >= NOW())") }
+  scope :displayable, ->{ active.current }
 end

--- a/app/views/admin/service_announcements/_form.html.haml
+++ b/app/views/admin/service_announcements/_form.html.haml
@@ -27,6 +27,12 @@
     = f.text_field :color, aria: { describedby: "Service Announcement Color" }
 
   %h4.ui.dividing.header Limits
+  .ui.info.message
+    %p Setting a start and end date allows the service announcement to handle the logic behind being shown and hidden automatically.
+    %ul.list
+      %li A lack of a starting date will result in the announcement being visible the from the moment it is created until the end date.
+      %li No end date will result in the announcement displaying indefinitely or until manually deactivated.
+
   .field
     = f.label :start_at
     = f.datetime_field :start_at, aria: { describedby: "Service Announcement Start At" }

--- a/app/views/admin/service_announcements/_form.html.haml
+++ b/app/views/admin/service_announcements/_form.html.haml
@@ -1,0 +1,38 @@
+= form_for [:admin, service_announcement], html: { class: "ui fluid form" } do |f|
+  - if service_announcement.errors.any?
+    .ui.message.error
+      %h2= "#{ pluralize service_announcement.errors.count, "error" } prohibited this service announcement from being saved:"
+      %ul
+        - service_announcement.errors.full_messages.each do |message|
+          %li= message
+
+  %h4.ui.dividing.header User Facing Info 
+
+  .required.field
+    = f.label :title
+    = f.text_field :title, aria: { describedby: "Service Announcement Title" }
+
+  .required.field
+    = f.label :message
+    = f.text_area :message, aria: { describedby: "Service Announcement Message" }
+
+  %h5.ui.dividing.header Visual Items
+
+  .field
+    = f.label :icon
+    = f.text_field :icon, aria: { describedby: "Service Announcement Icon" }
+
+  .field
+    = f.label :color
+    = f.text_field :color, aria: { describedby: "Service Announcement Color" }
+
+  %h4.ui.dividing.header Limits
+  .field
+    = f.label :start_at
+    = f.datetime_field :start_at, aria: { describedby: "Service Announcement Start At" }
+
+  .field
+    = f.label :end_at
+    = f.datetime_field :end_at, aria: { describedby: "Service Announcement End At" }
+
+  = f.submit "Save", class: "ui positive right floated submit button"

--- a/app/views/admin/service_announcements/_menu.html.haml
+++ b/app/views/admin/service_announcements/_menu.html.haml
@@ -1,0 +1,21 @@
+.ui.fluid.vertical.menu.sticky{ data: { behavior: "sticky", context: "#stickContext", offset: 75 } }
+  .item
+    .header
+      Service Announcements
+
+  = active_link_to admin_service_announcements_path, active: :exclusive, class: "item" do
+    Index
+    - if count
+      .ui.label= count
+
+  = active_link_to new_admin_service_announcement_path, class: "item" do
+    %i.plus.icon
+    New
+
+  -#.item
+    .ui.transparent.icon.input
+      = form_tag admin_service_announcements_path, method: :get do
+        = search_field_tag "q", params[:q], class: "ui prompt", placeholder: "Search ...", aria: { label: "search" }
+      %i.search.link.icon
+
+  = content_for :menu

--- a/app/views/admin/service_announcements/edit.html.haml
+++ b/app/views/admin/service_announcements/edit.html.haml
@@ -1,0 +1,11 @@
+- content_for :page_title do
+  Editing "#{ @service_announcement.title }"
+
+- content_for :body do
+  .ui.two.wide.column
+    .ui.row
+      = render partial: "menu", locals: { count: @count }
+
+  .ui.fourteen.wide.column
+    .ui.row
+      = render partial: "form", locals: { service_announcement: @service_announcement }

--- a/app/views/admin/service_announcements/edit.html.haml
+++ b/app/views/admin/service_announcements/edit.html.haml
@@ -1,11 +1,4 @@
 - content_for :page_title do
   Editing "#{ @service_announcement.title }"
 
-- content_for :body do
-  .ui.two.wide.column
-    .ui.row
-      = render partial: "menu", locals: { count: @count }
-
-  .ui.fourteen.wide.column
-    .ui.row
-      = render partial: "form", locals: { service_announcement: @service_announcement }
+= render partial: "form", locals: { service_announcement: @service_announcement }

--- a/app/views/admin/service_announcements/index.html.haml
+++ b/app/views/admin/service_announcements/index.html.haml
@@ -37,7 +37,7 @@
         %tbody
           - if @service_announcements.any?
             - @service_announcements.each do |service_announcement|
-              %tr{ class: [ (service_announcement.active ? "" : "disabled") ] }
+              %tr
                 %td.collapsing= check_box_tag "select-#{ service_announcement.id }", nil, false, data: { id: service_announcement.id, behavior: "select" }
                 %td.collapsing
                   .ui.buttons
@@ -52,9 +52,13 @@
                           %i.edit.icon
                           edit
 
-                        .item
-                          %i.hide.icon
-                          deactivate
+                        = link_to admin_service_announcement_toggle_index_path(service_announcement), class: "item", method: :post do
+                          - if service_announcement.active
+                            %i.hide.icon
+                            deactivate
+                          - else
+                            %i.unhide.icon
+                            activate
 
                         .divider
                         .header

--- a/app/views/admin/service_announcements/index.html.haml
+++ b/app/views/admin/service_announcements/index.html.haml
@@ -1,0 +1,82 @@
+- content_for :page_title do
+  Service Announcements
+
+- content_for :menu do
+  .item.hidden{ data: { behavior: "bulk-edit-menu" } }
+    .divider
+    .header Bulk Actions
+    .menu
+      .item
+        .ui.fluid.icon.button
+          %i.hide.icon
+          deactivate all
+
+      .item
+        .ui.fluid.icon.negative.basic.button
+          %i.trash.icon
+          delete all
+
+
+- content_for :body do
+  .ui.two.wide.column
+    .ui.row
+      = render partial: "menu", locals: { count: @count }
+
+  .ui.fourteen.wide.column
+    .ui.row
+      %table.ui.celled.table#stickContext
+        %thead
+          %tr
+            %th= check_box_tag "select-all", nil, false, data: { behavior: "select-all" }
+            %th Actions
+            %th Title
+            %th Message
+            %th Active?
+            %th Effective During
+            %th Created At
+        %tbody
+          - if @service_announcements.any?
+            - @service_announcements.each do |service_announcement|
+              %tr{ class: [ (service_announcement.active ? "" : "disabled") ] }
+                %td.collapsing= check_box_tag "select-#{ service_announcement.id }", nil, false, data: { id: service_announcement.id, behavior: "select" }
+                %td.collapsing
+                  .ui.buttons
+                    = link_to admin_service_announcement_path(service_announcement), class: "ui icon button" do 
+                      %i.expand.icon
+                      view
+
+                    .ui.simple.dropdown.icon.button
+                      %i.dropdown.icon
+                      .menu
+                        = link_to edit_admin_service_announcement_path(service_announcement), class: "item" do
+                          %i.edit.icon
+                          edit
+
+                        .item
+                          %i.hide.icon
+                          deactivate
+
+                        .divider
+                        .header
+                          %i.warning.sign.icon
+                          DANGERZONE
+
+                        .item{ data: { behavior: "modal", template: "admin/templates/service_announcements/delete", url: admin_service_announcement_path(service_announcement), title: service_announcement.title } }
+                          %i.trash.icon
+                          delete
+
+                %td= service_announcement.title
+                %td= service_announcement.message&.truncate(240)
+                %td.collapsing= service_announcement.active
+                %td.collapsing
+                  = service_announcement.start_at&.to_s(:long)
+                  \-
+                  = service_announcement.end_at&.to_s(:long)
+                %td.collapsing= service_announcement.created_at.to_s(:long)
+
+          - else
+            %tr
+              %td{ colspan: 7 }
+                No service announcements made yet
+
+      = paginate @service_announcements

--- a/app/views/admin/service_announcements/index.html.haml
+++ b/app/views/admin/service_announcements/index.html.haml
@@ -17,70 +17,63 @@
           delete all
 
 
-- content_for :body do
-  .ui.two.wide.column
-    .ui.row
-      = render partial: "menu", locals: { count: @count }
+%table.ui.celled.table#stickContext
+  %thead
+    %tr
+      %th= check_box_tag "select-all", nil, false, data: { behavior: "select-all" }
+      %th Actions
+      %th Title
+      %th Message
+      %th Active?
+      %th Effective During
+      %th Created At
+  %tbody
+    - if @service_announcements.any?
+      - @service_announcements.each do |service_announcement|
+        %tr
+          %td.collapsing= check_box_tag "select-#{ service_announcement.id }", nil, false, data: { id: service_announcement.id, behavior: "select" }
+          %td.collapsing
+            .ui.buttons
+              = link_to admin_service_announcement_path(service_announcement), class: "ui icon button" do 
+                %i.expand.icon
+                view
 
-  .ui.fourteen.wide.column
-    .ui.row
-      %table.ui.celled.table#stickContext
-        %thead
-          %tr
-            %th= check_box_tag "select-all", nil, false, data: { behavior: "select-all" }
-            %th Actions
-            %th Title
-            %th Message
-            %th Active?
-            %th Effective During
-            %th Created At
-        %tbody
-          - if @service_announcements.any?
-            - @service_announcements.each do |service_announcement|
-              %tr
-                %td.collapsing= check_box_tag "select-#{ service_announcement.id }", nil, false, data: { id: service_announcement.id, behavior: "select" }
-                %td.collapsing
-                  .ui.buttons
-                    = link_to admin_service_announcement_path(service_announcement), class: "ui icon button" do 
-                      %i.expand.icon
-                      view
+              .ui.simple.dropdown.icon.button
+                %i.dropdown.icon
+                .menu
+                  = link_to edit_admin_service_announcement_path(service_announcement), class: "item" do
+                    %i.edit.icon
+                    edit
 
-                    .ui.simple.dropdown.icon.button
-                      %i.dropdown.icon
-                      .menu
-                        = link_to edit_admin_service_announcement_path(service_announcement), class: "item" do
-                          %i.edit.icon
-                          edit
+                  = link_to admin_service_announcement_toggle_index_path(service_announcement), class: "item", method: :post do
+                    - if service_announcement.active
+                      %i.hide.icon
+                      deactivate
+                    - else
+                      %i.unhide.icon
+                      activate
 
-                        = link_to admin_service_announcement_toggle_index_path(service_announcement), class: "item", method: :post do
-                          - if service_announcement.active
-                            %i.hide.icon
-                            deactivate
-                          - else
-                            %i.unhide.icon
-                            activate
+                  .divider
+                  .header
+                    %i.warning.sign.icon
+                    DANGERZONE
 
-                        .divider
-                        .header
-                          %i.warning.sign.icon
-                          DANGERZONE
+                  .item{ data: { behavior: "modal", template: "admin/templates/service_announcements/delete", url: admin_service_announcement_path(service_announcement), title: service_announcement.title } }
+                    %i.trash.icon
+                    delete
 
-                        .item{ data: { behavior: "modal", template: "admin/templates/service_announcements/delete", url: admin_service_announcement_path(service_announcement), title: service_announcement.title } }
-                          %i.trash.icon
-                          delete
+          %td= service_announcement.title
+          %td= service_announcement.message&.truncate(240)
+          %td.collapsing= service_announcement.active
+          %td.collapsing
+            = service_announcement.start_at&.to_s(:long)
+            \-
+            = service_announcement.end_at&.to_s(:long)
+          %td.collapsing= service_announcement.created_at.to_s(:long)
 
-                %td= service_announcement.title
-                %td= service_announcement.message&.truncate(240)
-                %td.collapsing= service_announcement.active
-                %td.collapsing
-                  = service_announcement.start_at&.to_s(:long)
-                  \-
-                  = service_announcement.end_at&.to_s(:long)
-                %td.collapsing= service_announcement.created_at.to_s(:long)
+    - else
+      %tr
+        %td{ colspan: 7 }
+          No service announcements made yet
 
-          - else
-            %tr
-              %td{ colspan: 7 }
-                No service announcements made yet
-
-      = paginate @service_announcements
+= paginate @service_announcements

--- a/app/views/admin/service_announcements/new.html.haml
+++ b/app/views/admin/service_announcements/new.html.haml
@@ -1,11 +1,4 @@
 - content_for :page_title do
   New Service Announcement
 
-- content_for :body do
-  .ui.two.wide.column
-    .ui.row
-      = render partial: "menu", locals: { count: @count }
-
-  .ui.fourteen.wide.column
-    .ui.row
-      = render partial: "form", locals: { service_announcement: @service_announcement }
+= render partial: "form", locals: { service_announcement: @service_announcement }

--- a/app/views/admin/service_announcements/new.html.haml
+++ b/app/views/admin/service_announcements/new.html.haml
@@ -1,0 +1,11 @@
+- content_for :page_title do
+  New Service Announcement
+
+- content_for :body do
+  .ui.two.wide.column
+    .ui.row
+      = render partial: "menu", locals: { count: @count }
+
+  .ui.fourteen.wide.column
+    .ui.row
+      = render partial: "form", locals: { service_announcement: @service_announcement }

--- a/app/views/admin/service_announcements/show.html.haml
+++ b/app/views/admin/service_announcements/show.html.haml
@@ -1,77 +1,71 @@
 - content_for :page_title do
   Viewing "#{ @service_announcement.title }"
 
-- content_for :body do
-  .ui.two.wide.column
-    .ui.row
-      = render partial: "menu", locals: { count: @count }
+.ui.row
+  .ui.menu
+    = link_to edit_admin_service_announcement_path(@service_announcement), class: "item" do
+      %i.edit.icon
+      edit
 
-  .ui.fourteen.wide.column
-    .ui.row
-      .ui.menu
-        = link_to edit_admin_service_announcement_path(@service_announcement), class: "item" do
-          %i.edit.icon
-          edit
+    = link_to admin_service_announcement_toggle_index_path(@service_announcement), class: "item", method: :post do
+      - if @service_announcement.active
+        %i.hide.icon
+        deactivate
+      - else
+        %i.unhide.icon
+        activate
 
-        = link_to admin_service_announcement_toggle_index_path(@service_announcement), class: "item", method: :post do
-          - if @service_announcement.active
-            %i.hide.icon
-            deactivate
-          - else
-            %i.unhide.icon
-            activate
+    .right.menu
+      .item{ data: { behavior: "modal", template: "admin/templates/service_announcements/delete", url: admin_service_announcement_path(@service_announcement), title: @service_announcement.title } }
+        %i.trash.icon
+        delete
 
-        .right.menu
-          .item{ data: { behavior: "modal", template: "admin/templates/service_announcements/delete", url: admin_service_announcement_path(@service_announcement), title: @service_announcement.title } }
-            %i.trash.icon
-            delete
-
-      %h2.ui.dividing.header Internal Stuff
-      %table.ui.collapsing.celled.table
-        %tbody
-          %tr
-            %td
-              %b ID
-            %td
-              = @service_announcement.id
-          %tr
-            %td
-              %b Active?
-            %td
-              = @service_announcement.active
-          %tr
-            %td
-              %b Title
-            %td
-              = @service_announcement.title
-          %tr
-            %td
-              %b Message
-            %td
-              = @service_announcement.message
-          %tr
-            %td
-              %b Icon
-            %td
-              = @service_announcement.icon
-              %i.icon{ class: [ @service_announcement.color, @service_announcement.icon ] }
-          %tr
-            %td
-              %b Color
-            %td
-              = @service_announcement.color
-          %tr
-            %td
-              %b Start At
-            %td
-              = @service_announcement.start_at&.to_s(:long)
-          %tr
-            %td
-              %b End At
-            %td
-              = @service_announcement.end_at&.to_s(:long)
-          %tr
-            %td
-              %b Created At
-            %td
-              = @service_announcement.created_at.to_s(:long)
+  %h2.ui.dividing.header Internal Stuff
+  %table.ui.collapsing.celled.table
+    %tbody
+      %tr
+        %td
+          %b ID
+        %td
+          = @service_announcement.id
+      %tr
+        %td
+          %b Active?
+        %td
+          = @service_announcement.active
+      %tr
+        %td
+          %b Title
+        %td
+          = @service_announcement.title
+      %tr
+        %td
+          %b Message
+        %td
+          = @service_announcement.message
+      %tr
+        %td
+          %b Icon
+        %td
+          = @service_announcement.icon
+          %i.icon{ class: [ @service_announcement.color, @service_announcement.icon ] }
+      %tr
+        %td
+          %b Color
+        %td
+          = @service_announcement.color
+      %tr
+        %td
+          %b Start At
+        %td
+          = @service_announcement.start_at&.to_s(:long)
+      %tr
+        %td
+          %b End At
+        %td
+          = @service_announcement.end_at&.to_s(:long)
+      %tr
+        %td
+          %b Created At
+        %td
+          = @service_announcement.created_at.to_s(:long)

--- a/app/views/admin/service_announcements/show.html.haml
+++ b/app/views/admin/service_announcements/show.html.haml
@@ -21,6 +21,11 @@
             %i.unhide.icon
             activate
 
+        .right.menu
+          .item{ data: { behavior: "modal", template: "admin/templates/service_announcements/delete", url: admin_service_announcement_path(@service_announcement), title: @service_announcement.title } }
+            %i.trash.icon
+            delete
+
       %h2.ui.dividing.header Internal Stuff
       %table.ui.collapsing.celled.table
         %tbody

--- a/app/views/admin/service_announcements/show.html.haml
+++ b/app/views/admin/service_announcements/show.html.haml
@@ -1,0 +1,72 @@
+- content_for :page_title do
+  Viewing "#{ @service_announcement.title }"
+
+- content_for :body do
+  .ui.two.wide.column
+    .ui.row
+      = render partial: "menu", locals: { count: @count }
+
+  .ui.fourteen.wide.column
+    .ui.row
+      .ui.menu
+        = link_to edit_admin_service_announcement_path(@service_announcement), class: "item" do
+          %i.edit.icon
+          edit
+
+        = link_to admin_service_announcement_toggle_index_path(@service_announcement), class: "item", method: :post do
+          - if @service_announcement.active
+            %i.hide.icon
+            deactivate
+          - else
+            %i.unhide.icon
+            activate
+
+      %h2.ui.dividing.header Internal Stuff
+      %table.ui.collapsing.celled.table
+        %tbody
+          %tr
+            %td
+              %b ID
+            %td
+              = @service_announcement.id
+          %tr
+            %td
+              %b Active?
+            %td
+              = @service_announcement.active
+          %tr
+            %td
+              %b Title
+            %td
+              = @service_announcement.title
+          %tr
+            %td
+              %b Message
+            %td
+              = @service_announcement.message
+          %tr
+            %td
+              %b Icon
+            %td
+              = @service_announcement.icon
+              %i.icon{ class: [ @service_announcement.color, @service_announcement.icon ] }
+          %tr
+            %td
+              %b Color
+            %td
+              = @service_announcement.color
+          %tr
+            %td
+              %b Start At
+            %td
+              = @service_announcement.start_at&.to_s(:long)
+          %tr
+            %td
+              %b End At
+            %td
+              = @service_announcement.end_at&.to_s(:long)
+          %tr
+            %td
+              %b Created At
+            %td
+              = @service_announcement.created_at.to_s(:long)

--- a/app/views/bookmarks/_bookmarks_list.html.haml
+++ b/app/views/bookmarks/_bookmarks_list.html.haml
@@ -20,7 +20,9 @@
           .summary
             = check_box_tag "select-#{ bookmark.id }", nil, false, data: { id: bookmark.id, behavior: "select" }
             = link_to bookmark.title, bookmark_path(bookmark), class: "title"
-            .date= bookmark.created_at.to_s(:long)
+            .date
+              = distance_of_time_in_words_to_now(bookmark.created_at)
+              ago
 
           = link_to bookmark.uri_string, bookmark.uri_string
 

--- a/app/views/layouts/_body.html.haml
+++ b/app/views/layouts/_body.html.haml
@@ -2,6 +2,8 @@
 
 .ui.pusher
   .ui.main.container
+    = render partial: "layouts/service_announcements", locals: { service_announcements: @active_service_announcements }
+
     = semantic_flash
 
     = content_for :body

--- a/app/views/layouts/_body.html.haml
+++ b/app/views/layouts/_body.html.haml
@@ -2,7 +2,7 @@
 
 .ui.pusher
   .ui.main.container
-    = render partial: "layouts/service_announcements", locals: { service_announcements: @active_service_announcements }
+    = render_service_announcements
 
     = semantic_flash
 

--- a/app/views/layouts/_service_announcements.html.haml
+++ b/app/views/layouts/_service_announcements.html.haml
@@ -1,0 +1,11 @@
+- if service_announcements&.any?
+  - service_announcements.each do |service_announcement|
+    .ui.message{ class: [ service_announcement.color, (service_announcement.icon ? "icon" : "")] }
+      - if service_announcement.icon
+        %i.icon{ class: [ service_announcement.icon ] }
+
+      .content
+        .header
+          = service_announcement.title
+        %p
+          = service_announcement.message

--- a/app/views/layouts/admin/_body.html.haml
+++ b/app/views/layouts/admin/_body.html.haml
@@ -55,7 +55,7 @@
   .ui.main.horizontally.padded.grid
     .row
       .column
-        = render partial: "layouts/service_announcements", locals: { service_announcements: @active_service_announcements }
+        = render_service_announcements
 
         = semantic_flash
 

--- a/app/views/layouts/admin/_body.html.haml
+++ b/app/views/layouts/admin/_body.html.haml
@@ -55,6 +55,8 @@
   .ui.main.horizontally.padded.grid
     .row
       .column
+        = render partial: "layouts/service_announcements", locals: { service_announcements: @active_service_announcements }
+
         = semantic_flash
 
     = content_for :body

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,7 +42,9 @@ Rails.application.routes.draw do
   namespace :admin do
     root "home#home"
 
-    resources :service_announcements
+    resources :service_announcements do
+      resources :toggle, only: [ :create ], module: "service_announcements"
+    end
 
     resources :invitations
     resources :users, only: [ :index, :show, :edit, :update ] do

--- a/db/migrate/20180117175000_add_active_and_icon_to_service_announcements.rb
+++ b/db/migrate/20180117175000_add_active_and_icon_to_service_announcements.rb
@@ -1,0 +1,6 @@
+class AddActiveAndIconToServiceAnnouncements < ActiveRecord::Migration[5.2]
+  def change
+    add_column :service_announcements, :icon, :text
+    add_column :service_announcements, :active, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_01_15_145454) do
+ActiveRecord::Schema.define(version: 2018_01_17_175000) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -131,6 +131,8 @@ ActiveRecord::Schema.define(version: 2018_01_15_145454) do
     t.datetime "end_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "icon"
+    t.boolean "active", default: true
   end
 
   create_table "tags", force: :cascade do |t|


### PR DESCRIPTION
This is a little quick way to have persisted messages display to all users for a duration of time. Useful for downtime, upgrades/new features or other information that requires being seen by all users. They also support having a starting and ending date, along with being able to manually toggle them.

They look like so (icon and color are also configurable) in the admin panel and public facing sides:
![transientbug admin viewing testing 2018-01-17 21-52-34](https://user-images.githubusercontent.com/94542/35081323-d2317c1a-fbd0-11e7-9727-13921a7e29af.png)

![transientbug home 2018-01-17 21-54-08](https://user-images.githubusercontent.com/94542/35081343-f8bffdd4-fbd0-11e7-9f3b-50cf72b7caa6.png)
