### PR TITLE
Simplify parts of invitations

### DIFF
--- a/app/controllers/admin/invitations_controller.rb
+++ b/app/controllers/admin/invitations_controller.rb
@@ -66,7 +66,7 @@ class Admin::InvitationsController < AdminController
   end
 
   def invitation_params
-    params.require(:invitation).permit(:code, :internal_note, :title, :description, :limit)
+    params.require(:invitation).permit(:code, :internal_note, :title, :description, :available)
   end
 end
 

--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -44,7 +44,7 @@ class InvitesController < ApplicationController
   def set_invite
     @invitation = Invitation.find_by code: (params[:id] || params[:code])
 
-    redirect_to invites_path, error: "That invite isn't valid :(" unless @invitation
+    redirect_to invites_path, error: "That invite isn't valid :(" and return unless @invitation
 
     @invitations_user = @invitation.invitations_users.find_by id: session[:invite_reservation]
 
@@ -63,7 +63,7 @@ class InvitesController < ApplicationController
 
     row = result.to_a.first || {}
 
-    redirect_to invites_path, error: "That invite isn't valid :(" if row["available"]&.negative?
+    redirect_to invites_path, error: "That invite isn't valid :(" and return if row["available"]&.negative?
 
     @invitations_user = @invitation.invitations_users.create
     session[:invite_reservation] = @invitations_user.id

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -3,16 +3,10 @@ class Invitation < ApplicationRecord
   has_many :users, through: :invitation_users
 
   after_initialize :gen_code
-  before_validation :set_current
 
   private
 
   def gen_code
-    self.code ||= SecureRandom.hex(4)
-    self.limit ||= 1
-  end
-
-  def set_current
-    self.current ||= self.limit
+    self.code ||= SecureRandom.hex(4) # TODO: Make this safer since codes are unique
   end
 end

--- a/app/views/admin/invitations/_form.html.haml
+++ b/app/views/admin/invitations/_form.html.haml
@@ -26,8 +26,8 @@
       %p It's recommended to put a little internal note about what this invitation is for.
 
   .required.field
-    = f.label :limit
-    = f.number_field :limit, aria: { describedby: "Invitation Use Limit" }
+    = f.label :available
+    = f.number_field :available, aria: { describedby: "Invitation Available Uses" }
 
   - if invitation.new_record?
     .field

--- a/app/views/admin/invitations/index.html.haml
+++ b/app/views/admin/invitations/index.html.haml
@@ -16,7 +16,6 @@
           %i.trash.icon
           delete all
 
-
 - content_for :body do
   .ui.two.wide.column
     .ui.row
@@ -33,7 +32,6 @@
             %th Title
             %th Description
             %th Internal Note
-            %th Limit
             %th Available
             %th Created At
         %tbody
@@ -67,8 +65,7 @@
                 %td= invitation.title
                 %td= invitation.description&.truncate 120
                 %td= invitation.internal_note&.truncate 240
-                %td.collapsing= invitation.limit
-                %td.collapsing= invitation.current
+                %td.collapsing= invitation.available
                 %td.collapsing= invitation.created_at.to_s(:long)
 
           - else

--- a/app/views/admin/invitations/show.html.haml
+++ b/app/views/admin/invitations/show.html.haml
@@ -42,14 +42,9 @@
               = @invitation.code
           %tr
             %td
-              %b Limit
+              %b Currentlt Available
             %td
-              = @invitation.limit
-          %tr
-            %td
-              %b Current Available
-            %td
-              = @invitation.current
+              = @invitation.available
           %tr
             %td
               %b Created At

--- a/db/migrate/20180118154038_remove_limit_and_current_from_invitations.rb
+++ b/db/migrate/20180118154038_remove_limit_and_current_from_invitations.rb
@@ -1,0 +1,6 @@
+class RemoveLimitAndCurrentFromInvitations < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :invitations, :limit
+    remove_column :invitations, :current
+  end
+end

--- a/db/migrate/20180118154729_set_default_available_on_invitations.rb
+++ b/db/migrate/20180118154729_set_default_available_on_invitations.rb
@@ -1,0 +1,5 @@
+class SetDefaultAvailableOnInvitations < ActiveRecord::Migration[5.2]
+  def change
+    change_column_default :invitations, :available, 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_01_15_145454) do
+ActiveRecord::Schema.define(version: 2018_01_18_154729) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -95,10 +95,9 @@ ActiveRecord::Schema.define(version: 2018_01_15_145454) do
     t.text "internal_note"
     t.text "title"
     t.text "description"
-    t.integer "limit"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "current"
+    t.integer "available", default: 1
     t.index ["code"], name: "index_invitations_on_code", unique: true
   end
 
@@ -131,6 +130,8 @@ ActiveRecord::Schema.define(version: 2018_01_15_145454) do
     t.datetime "end_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "icon"
+    t.boolean "active", default: true
   end
 
   create_table "tags", force: :cascade do |t|


### PR DESCRIPTION
Current, available and limit columns on invitations is useless, and which column is being used wasn't consistent so this reduces it to one column, `available`, that is used for everything. It also sets a default and fixes a bug with redirects not happening resulting in 500s