### PR TITLE
break dockerfiles up so that only rails does the asset precompile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       - "redis"
     build:
       context: .
-    command: bundle exec sidekiq -C config/sidekiq.yml
+      dockerfile: dockerfiles/Dockerfile.sidekiq
     networks:
       - "services"
     env_file:
@@ -51,7 +51,7 @@ services:
       - "sidekiq"
     build:
       context: .
-    command: bundle exec clockwork clock.rb
+      dockerfile: dockerfiles/Dockerfile.clockwork
     networks:
       - "services"
     env_file:
@@ -64,6 +64,7 @@ services:
       - "redis"
     build:
       context: .
+      dockerfile: dockerfiles/Dockerfile.rails
     ports:
       - "8000:3000"
     volumes:
@@ -73,18 +74,13 @@ services:
       - "services"
     env_file:
       - ".env.production"
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost", "||", "exit", "1"]
-      interval: 1m
-      timeout: 10s
-      retries: 5
 
   cable:
     depends_on:
       - "redis"
     build:
       context: .
-    command: bundle exec puma -p 28080 cable/config.ru
+      dockerfile: dockerfiles/Dockerfile.cable
     ports:
       - "28080:28080"
     #volumes:

--- a/dockerfiles/Dockerfile.cable
+++ b/dockerfiles/Dockerfile.cable
@@ -1,0 +1,21 @@
+FROM ruby:2.4-alpine
+LABEL maintainer="Josh Ashby <me@joshisa.ninja>"
+
+RUN apk add --no-cache --update build-base postgresql-dev git curl
+
+RUN echo -e 'http://dl-cdn.alpinelinux.org/alpine/edge/main\nhttp://dl-cdn.alpinelinux.org/alpine/edge/community\nhttp://dl-cdn.alpinelinux.org/alpine/edge/testing' > /etc/apk/repositories && \
+    apk add --no-cache nodejs-current yarn
+
+RUN mkdir /app
+RUN mkdir /dropzone
+WORKDIR /app
+
+COPY Gemfile Gemfile.lock ./
+RUN echo "install: --no-document" > $HOME/.gemrc && echo "update: --no-document" >> $HOME/.gemrc
+RUN bundle install --binstubs --jobs 4 --without development test
+
+COPY . .
+
+VOLUME ["/dropzone"]
+
+CMD bundle exec puma -p 28080 cable/config.ru

--- a/dockerfiles/Dockerfile.clockwork
+++ b/dockerfiles/Dockerfile.clockwork
@@ -16,9 +16,6 @@ RUN bundle install --binstubs --jobs 4 --without development test
 
 COPY . .
 
-#ARG rails_master_key
-#RUN bundle exec rake RAILS_ENV=production RAILS_MASTER_KEY=$rails_master_key DATABASE_URL=postgresql://user:pass@127.0.0.1/dbname assets:precompile
+VOLUME ["/dropzone"]
 
-VOLUME ["/app/public", "/dropzone"]
-
-CMD bundle exec puma -C config/puma.rb
+CMD bundle exec clockwork clock.rb

--- a/dockerfiles/Dockerfile.rails
+++ b/dockerfiles/Dockerfile.rails
@@ -1,0 +1,23 @@
+FROM ruby:2.4-alpine
+LABEL maintainer="Josh Ashby <me@joshisa.ninja>"
+
+RUN apk add --no-cache --update build-base postgresql-dev git curl
+
+RUN echo -e 'http://dl-cdn.alpinelinux.org/alpine/edge/main\nhttp://dl-cdn.alpinelinux.org/alpine/edge/community\nhttp://dl-cdn.alpinelinux.org/alpine/edge/testing' > /etc/apk/repositories && \
+    apk add --no-cache nodejs-current yarn
+
+RUN mkdir /app
+RUN mkdir /dropzone
+WORKDIR /app
+
+COPY Gemfile Gemfile.lock ./
+RUN echo "install: --no-document" > $HOME/.gemrc && echo "update: --no-document" >> $HOME/.gemrc
+RUN bundle install --binstubs --jobs 4 --without development test
+
+COPY . .
+
+RUN bundle exec rake RAILS_ENV=production DATABASE_URL=postgresql://user:pass@127.0.0.1/dbname assets:precompile
+
+VOLUME ["/app/public", "/dropzone"]
+
+CMD bundle exec rake docs:generate && bundle exec puma -C config/puma.rb

--- a/dockerfiles/Dockerfile.sidekiq
+++ b/dockerfiles/Dockerfile.sidekiq
@@ -1,0 +1,21 @@
+FROM ruby:2.4-alpine
+LABEL maintainer="Josh Ashby <me@joshisa.ninja>"
+
+RUN apk add --no-cache --update build-base postgresql-dev git curl
+
+RUN echo -e 'http://dl-cdn.alpinelinux.org/alpine/edge/main\nhttp://dl-cdn.alpinelinux.org/alpine/edge/community\nhttp://dl-cdn.alpinelinux.org/alpine/edge/testing' > /etc/apk/repositories && \
+    apk add --no-cache nodejs-current yarn
+
+RUN mkdir /app
+RUN mkdir /dropzone
+WORKDIR /app
+
+COPY Gemfile Gemfile.lock ./
+RUN echo "install: --no-document" > $HOME/.gemrc && echo "update: --no-document" >> $HOME/.gemrc
+RUN bundle install --binstubs --jobs 4 --without development test
+
+COPY . .
+
+VOLUME ["/dropzone"]
+
+CMD bundle exec sidekiq -C config/sidekiq.yml


### PR DESCRIPTION
This came out of the fact that I keep precompiling the assets locally and end up with commits like 90722a10d4fc0d571f750cba403b23092e3a0706 as a result of the production box being undersized right now and unable to compile assets 4 times over for every service that gets built. Also this should allow for some flexibility in the different services which what other tools they might need or not need.