### PR TITLE
"Better" error capturing on offline caches

### DIFF
--- a/app/assets/javascripts/common.js
+++ b/app/assets/javascripts/common.js
@@ -4,6 +4,8 @@ document.addEventListener("turbolinks:load", () => {
     $(event.target).closest(".message").transition("fade")
   })
 
+  $(".ui.accordion").accordion()
+
   // Toggle the sidebar open and closed
   $(".sidebar.icon").parent().on("click", () => $(".ui.sidebar").sidebar("toggle"))
 
@@ -17,58 +19,6 @@ document.addEventListener("turbolinks:load", () => {
       stickySettings.offset = parseInt(stickySettings.offset)
 
     $(element).sticky(stickySettings)
-  })
-
-  // And now for select all and the bulk edit toolbar things. This also will
-  // refresh any sticky objects that the toolbars might be a part of
-  //
-  // TODO:
-  //   Could this all be done with like $("[data-behavior~=select]:checked").size()
-  //   checks?
-  const toggleBulkEditToolbar = (shouldShow) => {
-    let bulkEditItems = $("[data-group~=bulk-edit-menu]")
-    bulkEditItems.toggleClass("hidden", !shouldShow)
-
-    let sticky = bulkEditItems.parents("[data-behavior~=sticky]")
-
-    if(sticky)
-      sticky.sticky("refresh")
-  }
-
-  let selectCheckboxes = $("[data-behavior~=select]")
-  let selectAll = $("[data-behavior~=select-all]")
-
-  // If the select all is clicked or unclicked, update all of the selects
-  selectAll.on("change", (event) => {
-    let target = $(event.target)
-    let checked = target.prop("checked")
-
-    selectCheckboxes.prop("checked", checked)
-    toggleBulkEditToolbar(checked)
-  })
-
-  selectCheckboxes.on("change", (event) => {
-    let target = $(event.target)
-
-    if(target.prop("checked")) {
-      // If we're being checked, and all others are checked, check the select all
-      let allChecked = _.every(selectCheckboxes, (value, idx, col) => $(value).prop("checked"))
-
-      if(allChecked)
-        selectAll.prop("checked", true)
-
-      toggleBulkEditToolbar(true)
-    } else {
-      // If the select all is checked and we're being unchecked, uncheck the
-      // select all
-      if(selectAll.prop("checked"))
-        selectAll.prop("checked", false)
-
-      let allUnchecked = _.every(selectCheckboxes, (value, idx, col) => !$(value).prop("checked"))
-
-      if(allUnchecked)
-        toggleBulkEditToolbar(false)
-    }
   })
 
   // Setup autocomplete forms for image and bookmark tags. This could probably be simplified with data attributes.

--- a/app/controllers/admin/bookmarks_controller.rb
+++ b/app/controllers/admin/bookmarks_controller.rb
@@ -9,7 +9,7 @@ class Admin::BookmarksController < AdminController
     query_param = params[:q]
     base_where = bookmark_table[:id].eq(query_param)
 
-    @bookmarks = Bookmark.all
+    @bookmarks = Bookmark.includes(:webpage, :tags, :user).all
     @bookmarks = @bookmarks.where(base_where) if query_param.present? && !query_param.empty?
     @bookmarks = @bookmarks.order(created_at: :desc).page params[:page]
   end
@@ -34,7 +34,16 @@ class Admin::BookmarksController < AdminController
   private
 
   def set_bookmark
-    @bookmark = Bookmark.find params[:id]
+    @bookmark = Bookmark.includes(
+      :webpage,
+      :tags,
+      :user,
+      offline_caches: [
+        :error_messages,
+        :assets_attachments,
+        :assets_blobs
+      ]
+    ).find params[:id]
   end
 
   def set_count

--- a/app/controllers/admin/bookmarks_controller.rb
+++ b/app/controllers/admin/bookmarks_controller.rb
@@ -9,7 +9,7 @@ class Admin::BookmarksController < AdminController
     query_param = params[:q]
     base_where = bookmark_table[:id].eq(query_param)
 
-    @bookmarks = Bookmark.includes(:webpage, :tags, :user).all
+    @bookmarks = Bookmark.includes(:webpage, :tags, :user, offline_caches: [ :error_messages ]).all
     @bookmarks = @bookmarks.where(base_where) if query_param.present? && !query_param.empty?
     @bookmarks = @bookmarks.order(created_at: :desc).page params[:page]
   end

--- a/app/controllers/bookmarks/cache_controller.rb
+++ b/app/controllers/bookmarks/cache_controller.rb
@@ -8,7 +8,7 @@ class Bookmarks::CacheController < ApplicationController
 
   # GET /bookmarks/1/cache
   def index
-    render status: :not_found unless @bookmark.current_offline_cache
+    render :unavailable, status: :not_found unless @bookmark.current_offline_cache
     render html: renderer.render.html_safe
   end
 

--- a/app/helpers/admin/bookmarks_helper.rb
+++ b/app/helpers/admin/bookmarks_helper.rb
@@ -1,0 +1,20 @@
+module Admin::BookmarksHelper
+  def error_count_label error_messages
+    error_count = error_messages.count
+
+    icon = "smile"
+    color = "green"
+
+    if error_count > 0
+      icon = "warning circle"
+      color = "red"
+    end
+
+    content_tag :div, class: "ui label #{ color }" do
+      capture do
+        concat content_tag(:i, "", class: "icon #{ icon }")
+        concat "#{ error_count } Error".pluralize(error_count)
+      end
+    end
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -71,7 +71,7 @@ module ApplicationHelper
 
     options = {
       class: "hidden model-data",
-      id: "#{ model.class.to_s.underscore }-data",
+      id: "#{ model.class.to_s.underscore }-data-#{ model.id }",
       data: data
     }.merge opts
 
@@ -95,7 +95,7 @@ module ApplicationHelper
     data = {
       behavior: "neomodal",
       template: template,
-      storage: "#{ model.class.to_s.underscore }-data"
+      storage: "#{ model.class.to_s.underscore }-data-#{ model.id }"
     }.merge opts.except(:id, :class)
 
     options = {

--- a/app/jobs/webpage_cache_job.rb
+++ b/app/jobs/webpage_cache_job.rb
@@ -5,6 +5,7 @@ class WebpageCacheJob < ApplicationJob
   attr_reader :bookmark
 
   def perform bookmark:
-    WebpageCacheService::Cache.new(webpage: bookmark.webpage).exec
+    service = WebpageCacheService::Cache.new(webpage: bookmark.webpage).exec
+    bookmark.offline_caches << service.offline_cache
   end
 end

--- a/app/models/error_message.rb
+++ b/app/models/error_message.rb
@@ -1,0 +1,2 @@
+class ErrorMessage < ApplicationRecord
+end

--- a/app/models/offline_cache.rb
+++ b/app/models/offline_cache.rb
@@ -1,6 +1,8 @@
 class OfflineCache < ApplicationRecord
   belongs_to :webpage
+
   has_and_belongs_to_many :bookmarks
+  has_and_belongs_to_many :error_messages
 
   belongs_to :root, class_name: "ActiveStorage::Attachment", optional: true
 

--- a/app/policies/bookmark_policy.rb
+++ b/app/policies/bookmark_policy.rb
@@ -2,7 +2,7 @@ class BookmarkPolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
       # return scope.where(public: true) unless user.present?
-      # return scope.all if user.role? :admin
+      return scope.all if user.role? :admin
 
       scope.where(user: user).order(created_at: :desc)
     end

--- a/app/views/admin/bookmarks/index.html.haml
+++ b/app/views/admin/bookmarks/index.html.haml
@@ -25,6 +25,7 @@
       %th Creator
       %th URL
       %th Tags
+      %th Cache
       %th Created At
   %tbody
     - if @bookmarks.any?
@@ -57,6 +58,15 @@
           %td.collapsing= link_to bookmark.user.username, admin_user_path(bookmark.user)
           %td= bookmark.uri.to_s
           %td.collapsing= bookmark.tags.map(&:label).join ", "
+
+          %td.collapsing
+            - if bookmark.offline_caches.last
+              = error_count_label bookmark.offline_caches.last.error_messages
+            - else
+              .ui.label
+                %i.meh.icon
+                Uncached
+
           %td.collapsing= bookmark.created_at.to_s(:long)
 
     - else

--- a/app/views/admin/bookmarks/show.html.haml
+++ b/app/views/admin/bookmarks/show.html.haml
@@ -73,9 +73,9 @@
             - @bookmark.current_offline_cache.error_messages.each do |error_message|
               .item
                 %i.warning.circle.icon
-                  .content
-                    .header= error_message.key
-                    .description= error_message.message
+                .content
+                  .header= error_message.key
+                  .description= error_message.message
 
       .ui.column
         %h2.ui.dividing.header

--- a/app/views/admin/bookmarks/show.html.haml
+++ b/app/views/admin/bookmarks/show.html.haml
@@ -80,11 +80,10 @@
       .ui.column
         %h2.ui.dividing.header Cache History
 
-        - history_length = params.fetch(:cache_history, 5)
-        %p Last cache attempts shown (max: #{ history_length })
+        %p Last cache attempts shown
 
         .ui.feed
-          - @bookmark.offline_caches.order(created_at: :desc).limit(history_length).each do |offline_cache|
+          - @bookmark.offline_caches.reverse.each do |offline_cache|
             .event
               .label
                 %i.download.icon
@@ -95,6 +94,9 @@
                   .date= offline_cache.created_at.to_s(:long)
 
                 .extra.text
+                  - offline_cache_count = offline_cache.assets.count
+                  = offline_cache_count
+                  = "Asset".pluralize offline_cache_count
                   .ui.list
                     - offline_cache.assets.each do |asset|
                       .item

--- a/app/views/admin/bookmarks/show.html.haml
+++ b/app/views/admin/bookmarks/show.html.haml
@@ -109,3 +109,6 @@
                   - error_count = offline_cache.error_messages.count
                   = error_count
                   = "Error".pluralize(error_count)
+- else
+  %h2.ui.dividing.header Cache History
+  %p None :(

--- a/app/views/admin/bookmarks/show.html.haml
+++ b/app/views/admin/bookmarks/show.html.haml
@@ -80,7 +80,11 @@
       .ui.column
         %h2.ui.dividing.header Cache History
 
-        %p Last cache attempts shown
+        .ui.label
+          - offline_cache_count = @bookmark.offline_caches.count
+          %i.download.icon
+          = offline_cache_count
+          = "Cache".pluralize offline_cache_count
 
         .ui.feed
           - @bookmark.offline_caches.reverse.each do |offline_cache|
@@ -93,10 +97,25 @@
                   Recached at
                   .date= offline_cache.created_at.to_s(:long)
 
+                .meta
+                  -# TODO: Make this have a way to see what the errors were
+                  - error_count = offline_cache.error_messages.count
+                  - if error_count > 0
+                    - icon = "warning circle"
+                    - color = "red"
+                  - else
+                    - icon = "smile"
+                    - color = "green"
+
+                  .ui.label{ class: [ color ] }
+                    %i.icon{ class: [ icon ] }
+                    = error_count
+                    = "Error".pluralize(error_count)
+
                 .extra.text
-                  - offline_cache_count = offline_cache.assets.count
-                  = offline_cache_count
-                  = "Asset".pluralize offline_cache_count
+                  - asset_count = offline_cache.assets.count
+                  = asset_count
+                  = "Asset".pluralize asset_count
                   .ui.list
                     - offline_cache.assets.each do |asset|
                       .item
@@ -104,13 +123,6 @@
                         .content
                           .header= asset.blob.metadata.dig("uri")
                           .description= asset.blob.content_type
-
-                .meta
-                  -# TODO: Make this have a way to see what the errors were
-                  %i.warning.circle.icon
-                  - error_count = offline_cache.error_messages.count
-                  = error_count
-                  = "Error".pluralize(error_count)
 - else
   %h2.ui.dividing.header Cache History
   %p None :(

--- a/app/views/admin/bookmarks/show.html.haml
+++ b/app/views/admin/bookmarks/show.html.haml
@@ -78,13 +78,14 @@
                     .description= error_message.message
 
       .ui.column
-        %h2.ui.dividing.header Cache History
+        %h2.ui.dividing.header
+          Cache History
 
-        .ui.label
-          - offline_cache_count = @bookmark.offline_caches.count
-          %i.download.icon
-          = offline_cache_count
-          = "Cache".pluralize offline_cache_count
+          .ui.label
+            - offline_cache_count = @bookmark.offline_caches.count
+            %i.download.icon
+            = offline_cache_count
+            = "Cache".pluralize offline_cache_count
 
         .ui.feed
           - @bookmark.offline_caches.reverse.each do |offline_cache|
@@ -94,35 +95,26 @@
 
               .content
                 .summary
-                  Recached at
+                  Recached
                   .date= offline_cache.created_at.to_s(:long)
 
-                .meta
-                  -# TODO: Make this have a way to see what the errors were
-                  - error_count = offline_cache.error_messages.count
-                  - if error_count > 0
-                    - icon = "warning circle"
-                    - color = "red"
-                  - else
-                    - icon = "smile"
-                    - color = "green"
-
-                  .ui.label{ class: [ color ] }
-                    %i.icon{ class: [ icon ] }
-                    = error_count
-                    = "Error".pluralize(error_count)
-
                 .extra.text
-                  - asset_count = offline_cache.assets.count
-                  = asset_count
-                  = "Asset".pluralize asset_count
-                  .ui.list
-                    - offline_cache.assets.each do |asset|
-                      .item
-                        %i.file.icon
-                        .content
-                          .header= asset.blob.metadata.dig("uri")
-                          .description= asset.blob.content_type
+                  .ui.accordion
+                    .title
+                      %i.dropdown.icon
+                      - asset_count = offline_cache.assets.count
+                      = asset_count
+                      = "Asset".pluralize asset_count
+                      = error_count_label offline_cache.error_messages
+
+                    .content
+                      .ui.list
+                        - offline_cache.assets.each do |asset|
+                          .item
+                            %i.file.icon
+                            .content
+                              .header= asset.blob.metadata.dig("uri")
+                              .description= asset.blob.content_type
 - else
   %h2.ui.dividing.header Cache History
   %p None :(

--- a/app/views/admin/bookmarks/show.html.haml
+++ b/app/views/admin/bookmarks/show.html.haml
@@ -4,7 +4,7 @@
 = model_tag @bookmark, no_checkbox: true, only: [ :id, :title, :uri ]
 
 .ui.menu
-  = link_to bookmark_cache_index_path(@bookmark), class: "item" do
+  = link_to bookmark_cache_index_path(@bookmark), data: { turbolinks: false }, class: "item" do
     %i.eye.icon
     view cache
 

--- a/app/views/admin/bookmarks/show.html.haml
+++ b/app/views/admin/bookmarks/show.html.haml
@@ -4,6 +4,10 @@
 = model_tag @bookmark, no_checkbox: true, only: [ :id, :title, :uri ]
 
 .ui.menu
+  = link_to bookmark_cache_index_path(@bookmark), class: "item" do
+    %i.eye.icon
+    view cache
+
   = modal_tag @bookmark, :recache, url: admin_bookmark_cache_index_path(@bookmark) do
     %i.download.icon
     recache
@@ -13,7 +17,6 @@
       more
       %i.dropdown.icon
       .menu
-
         .header
           %i.warning.sign.icon
           DANGERZONE
@@ -56,5 +59,53 @@
       %td
         = @bookmark.created_at.to_s(:long)
 
-%h2.ui.dividing.header Cache History
-%p Coming Soon
+- if @bookmark.offline_caches.any?
+  .ui.equal.width.grid
+    .ui.row
+      .ui.column
+        %h2.ui.dividing.header Last Cache Errors
+
+        - if @bookmark.current_offline_cache.error_messages.empty?
+          %p Hurray! The last cache attempt had no error messages.
+
+        - else
+          .ui.list
+            - @bookmark.current_offline_cache.error_messages.each do |error_message|
+              .item
+                %i.warning.circle.icon
+                  .content
+                    .header= error_message.key
+                    .description= error_message.message
+
+      .ui.column
+        %h2.ui.dividing.header Cache History
+
+        - history_length = params.fetch(:cache_history, 5)
+        %p Last cache attempts shown (max: #{ history_length })
+
+        .ui.feed
+          - @bookmark.offline_caches.order(created_at: :desc).limit(history_length).each do |offline_cache|
+            .event
+              .label
+                %i.download.icon
+
+              .content
+                .summary
+                  Recached at
+                  .date= offline_cache.created_at.to_s(:long)
+
+                .extra.text
+                  .ui.list
+                    - offline_cache.assets.each do |asset|
+                      .item
+                        %i.file.icon
+                        .content
+                          .header= asset.blob.metadata.dig("uri")
+                          .description= asset.blob.content_type
+
+                .meta
+                  -# TODO: Make this have a way to see what the errors were
+                  %i.warning.circle.icon
+                  - error_count = offline_cache.error_messages.count
+                  = error_count
+                  = "Error".pluralize(error_count)

--- a/app/views/bookmarks/cache/unavailable.html.haml
+++ b/app/views/bookmarks/cache/unavailable.html.haml
@@ -1,0 +1,7 @@
+- content_for :page_title do
+  Offline Cache Unavailable :(
+
+%h2.ui.dividing.header Offline Cache Unavailable
+%p
+  Sad face, want to
+  = link_to "go back?", bookmark_path(@bookmark)

--- a/db/migrate/20180209210101_create_error_messages.rb
+++ b/db/migrate/20180209210101_create_error_messages.rb
@@ -1,0 +1,10 @@
+class CreateErrorMessages < ActiveRecord::Migration[5.2]
+  def change
+    create_table :error_messages do |t|
+      t.string :key
+      t.text :message
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180209210120_add_error_messages_to_offline_caches_join_table.rb
+++ b/db/migrate/20180209210120_add_error_messages_to_offline_caches_join_table.rb
@@ -1,0 +1,5 @@
+class AddErrorMessagesToOfflineCachesJoinTable < ActiveRecord::Migration[5.2]
+  def change
+    create_join_table :offline_caches, :error_messages
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_02_07_225108) do
+ActiveRecord::Schema.define(version: 2018_02_09_210120) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -83,6 +83,18 @@ ActiveRecord::Schema.define(version: 2018_02_07_225108) do
     t.jsonb "job_arguments"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "error_messages", force: :cascade do |t|
+    t.string "key"
+    t.text "message"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "error_messages_offline_caches", id: false, force: :cascade do |t|
+    t.bigint "offline_cache_id", null: false
+    t.bigint "error_message_id", null: false
   end
 
   create_table "images", force: :cascade do |t|

--- a/lib/webpage_cache_service/cache.rb
+++ b/lib/webpage_cache_service/cache.rb
@@ -74,6 +74,8 @@ class WebpageCacheService
     def links
       @links ||= ASSET_XPATHS.flat_map(&nokogiri.method(:xpath))
         .map(&:to_s)
+        .uniq
+        .compact
         .map(&Addressable::URI.method(:parse))
         .map { |link| uri + link }
     end

--- a/lib/webpage_cache_service/cache.rb
+++ b/lib/webpage_cache_service/cache.rb
@@ -56,9 +56,9 @@ class WebpageCacheService
         obj.save
       end
 
-      if response.status > 399
-        errors.create key: uri, message: "Got non-okay status back from the server: #{ response.status }"
-      end
+      errors.create key: uri, message: <<~MSG if response.status > 399
+        Got non-okay status back from the server: #{ response.status }
+      MSG
     end
 
     def cache_links
@@ -85,9 +85,9 @@ class WebpageCacheService
     def get uri:
       response = client.get uri
 
-      if response.status > 399
-        errors.create key: uri, message: "Got non-okay status back from the server: #{ response.status }"
-      end
+      errors.create key: uri, message: <<~MSG if response.status > 399
+        Got non-okay status back from the server: #{ response.status }
+      MSG
 
       # Without manually managing the temp file, there isn't an easy way to
       # breakup the following logic but I did my best and fuck you too rubocop

--- a/lib/webpage_cache_service/cache.rb
+++ b/lib/webpage_cache_service/cache.rb
@@ -43,6 +43,9 @@ class WebpageCacheService
       # Return self since there is an errors object and the offline cache model
       # that people might care about on this object.
       self
+    rescue => e
+      errors.create key: uri, message: e.message
+      self
     end
 
     private

--- a/lib/webpage_cache_service/cache.rb
+++ b/lib/webpage_cache_service/cache.rb
@@ -14,7 +14,7 @@ class WebpageCacheService
     def_delegator :@webpage, :uri
 
     def errors
-      offline_cache.errors
+      offline_cache.error_messages
     end
 
     def successful?
@@ -56,7 +56,6 @@ class WebpageCacheService
         obj.save
       end
 
-      errors.create key: uri, message: "Got non-okay status back from the server: #{ response.status }" if response.status > 399
     end
 
     def cache_links
@@ -83,7 +82,9 @@ class WebpageCacheService
     def get uri:
       response = client.get uri
 
-      errors.create key: uri, message: "Got non-okay status back from the server: #{ response.status }" if response.status > 399
+      if response.status > 399
+        errors.create key: uri, message: "Got non-okay status back from the server: #{ response.status }"
+      end
 
       # Without manually managing the temp file, there isn't an easy way to
       # breakup the following logic but I did my best and fuck you too rubocop

--- a/lib/webpage_cache_service/cache.rb
+++ b/lib/webpage_cache_service/cache.rb
@@ -14,7 +14,7 @@ class WebpageCacheService
     def_delegator :@webpage, :uri
 
     def errors
-      @errors ||= Errors.new
+      offline_cache.errors
     end
 
     def successful?
@@ -56,7 +56,7 @@ class WebpageCacheService
         obj.save
       end
 
-      errors.add uri, "Got non-okay status back from the server: #{ response.status }" if response.status > 399
+      errors.create key: uri, message: "Got non-okay status back from the server: #{ response.status }" if response.status > 399
     end
 
     def cache_links
@@ -82,6 +82,8 @@ class WebpageCacheService
 
     def get uri:
       response = client.get uri
+
+      errors.create key: uri, message: "Got non-okay status back from the server: #{ response.status }" if response.status > 399
 
       # Without manually managing the temp file, there isn't an easy way to
       # breakup the following logic but I did my best and fuck you too rubocop

--- a/lib/webpage_cache_service/cache.rb
+++ b/lib/webpage_cache_service/cache.rb
@@ -56,6 +56,9 @@ class WebpageCacheService
         obj.save
       end
 
+      if response.status > 399
+        errors.create key: uri, message: "Got non-okay status back from the server: #{ response.status }"
+      end
     end
 
     def cache_links

--- a/lib/webpage_cache_service/cache.rb
+++ b/lib/webpage_cache_service/cache.rb
@@ -33,6 +33,7 @@ class WebpageCacheService
       headers.delete key
     end
 
+    # rubocop:disable Lint/RescueWithoutErrorClass
     def exec
       cache_root
 
@@ -47,6 +48,7 @@ class WebpageCacheService
       errors.create key: uri, message: e.message
       self
     end
+    # rubocop:enable Lint/RescueWithoutErrorClass
 
     private
 

--- a/spec/factories/error_messages.rb
+++ b/spec/factories/error_messages.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :error_message do
+    key "MyString"
+    message "MyText"
+  end
+end

--- a/spec/models/error_message_spec.rb
+++ b/spec/models/error_message_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ErrorMessage, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/error_message_spec.rb
+++ b/spec/models/error_message_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe ErrorMessage, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end


### PR DESCRIPTION
Also displays a history of the caches in the admin panel (max displayed is hacked right now)
and the errors from the last cache, making it a little easier to quickly find problems and see the state of things in production.

![transientbug admin bookmarks 2018-02-10 14-56-09](https://user-images.githubusercontent.com/94542/36067038-904d7736-0e72-11e8-8074-ea9625c3c0dc.png)

![transientbug admin bookmarks 2018-02-10 14-57-46](https://user-images.githubusercontent.com/94542/36067051-cb6fbdec-0e72-11e8-98a3-b4c8bc17b9a1.png)

![monosnap 2018-02-10 14-58-23](https://user-images.githubusercontent.com/94542/36067056-dd8328fc-0e72-11e8-97b3-c733fc261606.png)

![transientbug admin bookmarks 2018-02-10 15-17-17](https://user-images.githubusercontent.com/94542/36067188-819e318c-0e75-11e8-9e6e-9ae0511e8be2.png)
