### PR TITLE
try more rewinds on the temp_file to be really safe

### DIFF
--- a/app/controllers/bookmarks/cache_controller.rb
+++ b/app/controllers/bookmarks/cache_controller.rb
@@ -9,6 +9,10 @@ class Bookmarks::CacheController < ApplicationController
   # GET /bookmarks/1/cache
   def index
     render :unavailable, status: :not_found unless @bookmark.current_offline_cache
+
+    root_blob = @bookmark.current_offline_cache.root.blob
+    render :unavailable, status: :not_found unless root_blob.service.exist? root_blob.key
+
     render html: renderer.render.html_safe
   end
 


### PR DESCRIPTION
Also, better unavailable notice for missing blob files causes reasons.

I'm guessing that cache blobs weren't getting saved because the temp file handler wasn't getting rewound so the blob was getting set to an empty handle.