### PR TITLE
return self even if the cacher can't parse the file

### DIFF
--- a/app/jobs/webpage_cache_job.rb
+++ b/app/jobs/webpage_cache_job.rb
@@ -4,6 +4,11 @@ class WebpageCacheJob < ApplicationJob
   queue_as :default
   attr_reader :bookmark
 
+  rescue_from(ActiveJob::DeserializationError) do |exception|
+    Rails.logger.debug "Failed to find parameters"
+    Rails.logger.debug exception
+  end
+
   def perform bookmark:
     service = WebpageCacheService::Cache.new(webpage: bookmark.webpage).exec
     bookmark.offline_caches << service.offline_cache

--- a/lib/webpage_cache_service/cache.rb
+++ b/lib/webpage_cache_service/cache.rb
@@ -37,7 +37,7 @@ class WebpageCacheService
     def exec
       cache_root
 
-      return unless PARSABLE_MIMES.include? @root_attachment.blob.content_type
+      return self unless PARSABLE_MIMES.include? @root_attachment.blob.content_type
 
       cache_links
 


### PR DESCRIPTION
This should quiet down the exceptions from this job complaining about
```
sidekiq_1        | 2018-03-05T15:24:06.176Z 1 TID-gs3uyar0w WARN: NoMethodError: undefined method `offline_cache' for nil:NilClass
sidekiq_1        | 2018-03-05T15:24:06.176Z 1 TID-gs3uyar0w WARN: /app/app/jobs/webpage_cache_job.rb:9:in `perform'
```