### PR TITLE
turns out you don't always own the authorized app

### DIFF
--- a/app/policies/doorkeeper/application_policy.rb
+++ b/app/policies/doorkeeper/application_policy.rb
@@ -4,7 +4,7 @@ class Doorkeeper::ApplicationPolicy < ApplicationPolicy
       # return scope.where(public: true) unless user.present?
       # return scope.all if user.role? :admin
 
-      scope.where(owner: user).order(created_at: :desc)
+      scope.order(created_at: :desc)
     end
   end
 


### PR DESCRIPTION
But you still have an authorization for it, so while this was showing a list of authorized apps for my user because I also owned them, it was showing nothing for other users even after they authorized an app to access their account.

And yes, someday I should get tests around this kind of thing.