### PR TITLE
remove the simulate link from apitome because its being stupid

### DIFF
--- a/app/views/apitome/docs/_example.html.erb
+++ b/app/views/apitome/docs/_example.html.erb
@@ -1,0 +1,26 @@
+<h2><%= example['description'] %></h2>
+
+<%= render partial: 'apitome/docs/explanation',    locals: {explaination: example['explanation']} if example['explanation'] %>
+<%= render partial: 'apitome/docs/endpoint',       locals: {method: example['http_method'], endpoint: example['route']} %>
+<%= render partial: 'apitome/docs/params',         locals: {params: example['parameters']} if example['parameters'].size > 0 %>
+
+<% example['requests'].each_with_index do |request, index| %>
+  <div id="<%= "request-#{index}" %>">
+    <h3><%= t(:request, scope: :apitome) %></h3>
+    <div class="request">
+      <%= render partial: 'apitome/docs/route',    locals: {request: request, index: index} %>
+      <%= render partial: 'apitome/docs/headers',  locals: {request: request, index: index, headers: request['request_headers']} %>
+      <%= render partial: 'apitome/docs/query',    locals: {request: request, index: index} unless request['request_query_parameters'].empty? %>
+      <%= render partial: 'apitome/docs/body',     locals: {request: request, index: index, body: request['request_body'], type: request['request_content_type']} if request['request_body'] %>
+      <%= render partial: 'apitome/docs/curl',     locals: {request: request, index: index} if request['curl'] %>
+    </div>
+
+    <h3><%= t(:response, scope: :apitome) %></h3>
+    <div class="response">
+      <%= render partial: 'apitome/docs/response_fields', locals: {params: example['response_fields']} if example['response_fields'].size > 0 %>
+      <%= render partial: 'apitome/docs/status',          locals: {request: request, index: index} %>
+      <%= render partial: 'apitome/docs/headers',         locals: {request: request, index: index, headers: request['response_headers']} %>
+      <%= render partial: 'apitome/docs/body',            locals: {request: request, index: index, body: request['response_body'], type: request['response_content_type']} if request['response_body'] %>
+    </div>
+  </div>
+<% end %>


### PR DESCRIPTION
Apitome or rspec_api_documentation is being stupid and it's resulting in the simulate link being broken. The data doesn't even seem to be stored anywhere in the generated data from the tests so for now I'm just going to remove the link and deal with it later when I have ~time~ motivation to dig into the gems more.