### PR TITLE
Feature/tag ui update

### DIFF
--- a/app/assets/javascripts/common.js
+++ b/app/assets/javascripts/common.js
@@ -21,7 +21,8 @@ document.addEventListener("turbolinks:load", () => {
     $(element).sticky(stickySettings)
   })
 
-  // Setup autocomplete forms for image and bookmark tags. This could probably be simplified with data attributes.
+  // Setup autocomplete forms for image and bookmark tags. This could probably
+  // be simplified with data attributes.
   $("[data-behavior~=autocomplete-image-tags]").dropdown({
     apiSettings: {
       cache: false,
@@ -33,16 +34,9 @@ document.addEventListener("turbolinks:load", () => {
     }
   })
 
-  $("[data-behavior~=autocomplete-bookmark-tags]").dropdown({
-    apiSettings: {
-      cache: false,
-      action: "autocomplete bookmark tags"
-    },
-    fields: {
-      name: "label",
-      value: "label"
-    }
-  })
+  // TODO: Need to refactor some bits of the image stuff in another PR
+  //tagDropdown("[data-behavior~=autocomplete-image-tags]", "autocomplete image tags")
+  tagDropdown("[data-behavior~=autocomplete-bookmark-tags]", "autocomplete bookmark tags")
 
   // Setup searching for things. This could probably be simplified with data attributes.
   $("[data-behavior~=search-images]").search({
@@ -81,11 +75,27 @@ document.addEventListener("turbolinks:load", () => {
     inline: true
   })
 
-  $("[data-behavior~=tag-edit-popup]").popup({
-    inline: true,
-    position: "bottom left",
-    on: 'click'
-  })
-
   $("[data-behavior~=dropdown]").dropdown()
 })
+
+const tagDropdown = (selector, action) => {
+  // This is a massive hack to get around FireFox caching hidden input field
+  // data because its all awful
+  const tagInput = $(`${ selector } > input[data-behaviour~=\"init\"]`)
+  if(tagInput.length > 0) {
+    const rawTags = tagInput.val()
+    const tags = rawTags.split(",").map((t) => ({ name: t, value: t, label: t, selected: true }))
+
+    $(selector).dropdown({
+      apiSettings: {
+        cache: false,
+        action
+      },
+      fields: {
+        name: "label",
+        value: "label"
+      },
+      values: tags
+    })
+  }
+}

--- a/app/assets/javascripts/common.js
+++ b/app/assets/javascripts/common.js
@@ -21,22 +21,21 @@ document.addEventListener("turbolinks:load", () => {
     $(element).sticky(stickySettings)
   })
 
-  // Setup autocomplete forms for image and bookmark tags. This could probably
-  // be simplified with data attributes.
-  $("[data-behavior~=autocomplete-image-tags]").dropdown({
-    apiSettings: {
-      cache: false,
-      action: "autocomplete image tags"
-    },
-    fields: {
+  tagDropdown(
+    "[data-behavior~=autocomplete-image-tags]",
+    "autocomplete image tags", {
       name: "title",
       value: "title"
     }
-  })
+  )
 
-  // TODO: Need to refactor some bits of the image stuff in another PR
-  //tagDropdown("[data-behavior~=autocomplete-image-tags]", "autocomplete image tags")
-  tagDropdown("[data-behavior~=autocomplete-bookmark-tags]", "autocomplete bookmark tags")
+  tagDropdown(
+    "[data-behavior~=autocomplete-bookmark-tags]",
+    "autocomplete bookmark tags", {
+      name: "label",
+      value: "label"
+    }
+  )
 
   // Setup searching for things. This could probably be simplified with data attributes.
   $("[data-behavior~=search-images]").search({
@@ -78,23 +77,20 @@ document.addEventListener("turbolinks:load", () => {
   $("[data-behavior~=dropdown]").dropdown()
 })
 
-const tagDropdown = (selector, action) => {
+const tagDropdown = (selector, action, fields) => {
   // This is a massive hack to get around FireFox caching hidden input field
   // data because its all awful
   const tagInput = $(`${ selector } > input[data-behaviour~=\"init\"]`)
-  if(tagInput.length > 0) {
+  if(tagInput.length != 0) {
     const rawTags = tagInput.val()
-    const tags = rawTags.split(",").map((t) => ({ name: t, value: t, label: t, selected: true }))
+    const tags = rawTags.split(",").map((t) => ({ name: t, value: t, label: t, title: t, selected: true }))
 
     $(selector).dropdown({
       apiSettings: {
         cache: false,
         action
       },
-      fields: {
-        name: "label",
-        value: "label"
-      },
+      fields,
       values: tags
     })
   }

--- a/app/assets/javascripts/common.js
+++ b/app/assets/javascripts/common.js
@@ -81,5 +81,11 @@ document.addEventListener("turbolinks:load", () => {
     inline: true
   })
 
+  $("[data-behavior~=tag-edit-popup]").popup({
+    inline: true,
+    position: "bottom left",
+    on: 'click'
+  })
+
   $("[data-behavior~=dropdown]").dropdown()
 })

--- a/app/assets/javascripts/public_init.js
+++ b/app/assets/javascripts/public_init.js
@@ -16,4 +16,6 @@ App.registerInitializer("semantic-ui api", () => {
 
     return settings
   }
+
+  $.fn.dropdown.settings.selector.input = "> input[data-behaviour~=\"init\"], > select"
 })

--- a/app/assets/stylesheets/public.scss
+++ b/app/assets/stylesheets/public.scss
@@ -14,3 +14,18 @@
  *= require_self
  */
 @import "common";
+
+
+.bookmarks.list {
+  .item {
+    .inline {
+      .header {
+        display: inline-block;
+      }
+
+      .date {
+        display: inline-block;
+      }
+    }
+  }
+}

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -70,7 +70,7 @@ class ImagesController < ApplicationController
   # POST /images.json
   def create
     image_param = params.dig(:image, :image)
-    tags = params.dig(:image, :tags).reject(&:empty?).map(&:strip)
+    tags = params.dig(:image, :tags).split(",").reject(&:empty?).map(&:strip)
 
     @image = current_user.images.new(image_params.merge(tags: tags))
 
@@ -90,7 +90,7 @@ class ImagesController < ApplicationController
   # PATCH/PUT /images/1.json
   def update
     image_param = params.dig(:image, :image)
-    tags = params.dig(:image, :tags).reject(&:empty?).map(&:strip)
+    tags = params.dig(:image, :tags).split(",").reject(&:empty?).map(&:strip)
 
     respond_to do |format|
       if @image.update(image_params.merge(tags: tags))

--- a/app/views/bookmarks/_bookmarks_list.html.haml
+++ b/app/views/bookmarks/_bookmarks_list.html.haml
@@ -15,13 +15,15 @@
         %i.trash.icon
         delete all
 
-  .ui.relaxed.divided.selection.bookmarks.list
+  .ui.relaxed.divided.bookmarks.list
     - bookmarks.each do |bookmark|
       .ui.item
         .right.floated.content
-          - bookmark.tags.each do |tag|
-            = link_to bookmarks_tag_path(tag) do
-              .ui.label{ class: [tag.color] }= tag.label
+          .ui.labels
+            - bookmark.tags.each do |tag|
+              = link_to bookmarks_tag_path(tag) do
+                .ui.label{ class: [tag.color] }= tag.label
+
         .content
           .inline
             = model_tag bookmark, only: [:uri, :title]

--- a/app/views/bookmarks/_bookmarks_list.html.haml
+++ b/app/views/bookmarks/_bookmarks_list.html.haml
@@ -15,42 +15,25 @@
         %i.trash.icon
         delete all
 
-  .ui.feed
+  .ui.relaxed.divided.selection.bookmarks.list
     - bookmarks.each do |bookmark|
-      .event
-        .label
-          %i.bookmark.icon
+      .ui.item
+        .right.floated.content
+          - bookmark.tags.each do |tag|
+            = link_to bookmarks_tag_path(tag) do
+              .ui.label{ class: [tag.color] }= tag.label
         .content
-          .summary
+          .inline
             = model_tag bookmark, only: [:uri, :title]
 
-            = link_to bookmark.title, bookmark_path(bookmark), class: "title"
+            .header= link_to bookmark.title, bookmark_path(bookmark)
+
             .date
               = distance_of_time_in_words_to_now(bookmark.created_at)
               ago
 
-          = link_to bookmark.uri.to_s, bookmark.uri.to_s
-
-          - if bookmark.description.present?
-            = bookmark.description&.truncate(240)
-            = link_to "read more", bookmark_path(bookmark)
-
-          .ui.fluid.text.menu
-            .ui.item
-              %i.tags.icon
-              = bookmark.tags.length
-              = "tag".pluralize(bookmark.tags.length)
-
-            - if bookmark.offline_caches.any?
-              = link_to "offline cache", bookmark_cache_index_path(bookmark), data: { turbolinks: false }, class: "ui item"
-
-            = link_to "edit", edit_bookmark_path(bookmark), class: "ui item"
-
-            .right.menu
-              = modal_tag bookmark, url: bookmark_path(bookmark), template: "public/templates/bookmarks/delete" do
-                delete
-
-          .ui.divider
+          .description
+            = link_to bookmark.uri.to_s, bookmark.uri.to_s
 
 - else
   %h1.huge.center.aligned.icon.header

--- a/app/views/bookmarks/_form.html.haml
+++ b/app/views/bookmarks/_form.html.haml
@@ -1,4 +1,4 @@
-= form_for bookmark, html: { class: "ui fluid form" } do |f|
+= form_with model: bookmark, class: "ui fluid form", html: { autocomplete: "off" } do |f|
   - if bookmark.errors.any?
     .ui.message.error
       %h2= "#{ pluralize bookmark.errors.count, "error" } prohibited this bookmark from being saved:"
@@ -6,23 +6,24 @@
         - bookmark.errors.full_messages.each do |message|
           %li= message
 
-  .required.field
-    = f.label :uri
-    = f.url_field :uri, aria: { describedby: "Bookmark URL" }, value: bookmark.uri.to_s
+  .two.fields
+    .required.field
+      = f.label :uri
+      = f.url_field :uri, aria: { describedby: "Bookmark URL" }, value: bookmark.uri.to_s
 
-  .required.field
-    = f.label :title
-    = f.text_field :title, aria: { describedby: "Bookmark title" }
-
-  .field
-    = f.label :description
-    = f.text_area :description, aria: { describedby: "Bookmark description" }
+    .required.field
+      = f.label :title
+      = f.text_field :title, aria: { describedby: "Bookmark title" }
 
   .field
     = f.label :tags
     .ui.multiple.search.selection.dropdown{ data: { behavior: "autocomplete-bookmark-tags" } }
-      = f.hidden_field :tags, value: bookmark.tags.map(&:label).join(",")
+      = f.text_field :tags, value: bookmark.tags.map(&:label).join(","), style: "display: none", autocomplete: "off", data: { behaviour: "init" }
       %i.dropdown.icon
       .default.text Search Tags
+
+  .field
+    = f.label :description
+    = f.text_area :description, aria: { describedby: "Bookmark description" }
 
   = f.submit "Save", class: "ui positive right floated submit button"

--- a/app/views/bookmarks/show.html.haml
+++ b/app/views/bookmarks/show.html.haml
@@ -11,7 +11,7 @@
   = @bookmark.created_at.to_s(:long)
   UTC
 
-.ui.small.tag.labels
+.ui.small.labels
   - @bookmark.tags.each do |tag|
     = link_to bookmarks_tag_path(tag) do
       .ui.label{ class: [tag.color] }= tag.label

--- a/app/views/bookmarks/tags/show.html.haml
+++ b/app/views/bookmarks/tags/show.html.haml
@@ -4,6 +4,6 @@
 = render "bookmarks/navbar"
 
 %h1
-  .ui.massive.label.tag{ class: [ @tag.color ] }= @tag.label
+  .ui.massive.tag{ class: [ @tag.color ] }= @tag.label
 
 = render partial: "bookmarks/bookmarks_list", locals: { bookmarks: @bookmarks }

--- a/app/views/images/_form.html.haml
+++ b/app/views/images/_form.html.haml
@@ -12,7 +12,10 @@
 
   .field
     = f.label :tags
-    = f.select :tags, image.tags.map { |t| [ t, t ] }, {}, { multiple: true, class: "ui multiple search selection dropdown", data: { behavior: "autocomplete-image-tags" } }
+    .ui.multiple.search.selection.dropdown{ data: { behavior: "autocomplete-image-tags" } }
+      = f.text_field :tags, value: image.tags.join(","), style: "display: none", autocomplete: "off", data: { behaviour: "init" }
+      %i.dropdown.icon
+      .default.text Search Tags
 
   .field
     = f.label :source

--- a/app/views/layouts/admin.html.haml
+++ b/app/views/layouts/admin.html.haml
@@ -3,9 +3,9 @@
   %head
     = render partial: "layouts/admin/head"
 
+    = javascript_include_tag "admin", "data-turbolinks-track": "reload", "data-turbolinks-eval": false
+
   %body{ class: [  controller_name, action_name ] }
     = render partial: "layouts/admin/body"
 
     = render partial: "layouts/admin/footer"
-
-  = javascript_include_tag "admin", "data-turbolinks-track": "reload", "data-turbolinks-eval": false

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -3,9 +3,9 @@
   %head
     = render partial: "layouts/head"
 
+    = javascript_include_tag "public", "data-turbolinks-track": "reload", "data-turbolinks-eval": false
+
   %body{ class: [  controller_name, action_name ] }
     = render partial: "layouts/body"
 
     = render partial: "layouts/footer"
-
-  = javascript_include_tag "public", "data-turbolinks-track": "reload", "data-turbolinks-eval": false


### PR DESCRIPTION
This fixes the issue of tags not showing up when editing exiting bookmarks (and images). This was partially happening as a result of semantic-ui not loading the hidden inputs values when initializing, and firefox caching values of [hidden](https://stackoverflow.com/a/21726727) [inputs](https://stackoverflow.com/q/31495222).

I also did a small UI tweak for editing and the list view on bookmarks to expose tags a bit more.

![transientbug editing bookmark how to write a memoir while grieving 2018-07-11 11-59-35](https://user-images.githubusercontent.com/94542/42590761-ebc08bca-8501-11e8-9226-95e7ccd3d80a.png)
![transientbug bookmarks 2018-07-11 12-00-16](https://user-images.githubusercontent.com/94542/42590789-016adb2e-8502-11e8-9963-209bcfc85dca.png)
