### PR TITLE
Update bookmark show view

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -16,7 +16,12 @@ html, body{
 }
 
 .main.container, .main.grid {
-  margin-top: 5em;
+  margin-top: 53px;
+
+  & > .margined {
+    margin-right: 5em;
+    margin-left: 5em;
+  }
 }
 
 .item.padder {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -78,9 +78,12 @@ module ApplicationHelper
       data: data
     }.merge opts
 
+    display = "display: inline"
+    display = "display: none" if no_checkbox
+
     # Ensures that when we grab the siblings of the checkboxes that are
     # checked, that we'll end up with the correct div containing all the datas
-    tag.div style: "display: inline" do
+    tag.div style: display do
       capture do
         concat tag.div(**options, &block)
         concat bulk_edit_checkbox model unless no_checkbox

--- a/app/views/bookmarks/show.html.haml
+++ b/app/views/bookmarks/show.html.haml
@@ -3,30 +3,36 @@
 
 = model_tag @bookmark, only: [ :uri, :title ], no_checkbox: true
 
-%h2.ui.header
-  .content= @bookmark.title
+- content_for :non_fluid do
+  .ui.fluid.secondary.pointing.menu
+    - if @bookmark.offline_caches.any?
+      = link_to "offline cache", bookmark_cache_index_path(@bookmark), data: { turbolinks: false }, class: "ui item"
 
-= link_to @bookmark.uri.to_s, @bookmark.uri.to_s
-.date
-  = @bookmark.created_at.to_s(:long)
-  UTC
+    = link_to "edit", edit_bookmark_path(@bookmark), class: "ui item"
 
-.ui.small.labels
-  - @bookmark.tags.each do |tag|
-    = link_to bookmarks_tag_path(tag) do
-      .ui.label{ class: [tag.color] }= tag.label
+    .ui.item
+      .ui.small.labels
+        - @bookmark.tags.each do |tag|
+          = link_to bookmarks_tag_path(tag) do
+            .ui.label{ class: [tag.color] }= tag.label
 
-.ui.fluid.menu
-  - if @bookmark.offline_caches.any?
-    = link_to "offline cache", bookmark_cache_index_path(@bookmark), data: { turbolinks: false }, class: "ui item"
+    .right.menu
+      = link_to "recache", bookmark_cache_index_path(@bookmark), method: :post, class: "ui item"
 
-  = link_to "edit", edit_bookmark_path(@bookmark), class: "ui item"
+      = modal_tag @bookmark, :delete, url: bookmark_path(@bookmark) do
+        delete
 
-  .right.menu
-    = link_to "recache", bookmark_cache_index_path(@bookmark), method: :post, class: "ui item"
+.ui.grid
+  .eight.wide.column
+    %h2.ui.header
+      .content= @bookmark.title
 
-    = modal_tag @bookmark, :delete, url: bookmark_path(@bookmark) do
-      delete
+    = link_to @bookmark.uri.to_s, @bookmark.uri.to_s
+    .date
+      = @bookmark.created_at.to_s(:long)
+      UTC
 
-- if @bookmark.description.present?
-  = simple_format @bookmark.description
+
+  .eight.wide.column
+    - if @bookmark.description.present?
+      = simple_format @bookmark.description

--- a/app/views/layouts/_body.html.haml
+++ b/app/views/layouts/_body.html.haml
@@ -4,9 +4,11 @@
   .ui.loader#page-loader
 
 .ui.pusher
-  .ui.main.container
-    = render_service_announcements
+  .ui.main.fluid.container
+    = content_for :non_fluid
 
-    = semantic_flash
+    .margined
+      = render_service_announcements
 
-    = yield
+      = semantic_flash
+      = yield


### PR DESCRIPTION
This changes the bookmarks show view into a fluid design to match the new fluid navbar in #59 and updates it to get ready for some new features like favicon display and context extraction.

![transientbug bookmark how to write a memoir while grieving 2018-08-17 10-01-48](https://user-images.githubusercontent.com/94542/44276554-0a87ac80-a205-11e8-94a1-7e5a8e574a4f.png)
