### PR TITLE
Fix/delete button

### DIFF
--- a/app/assets/javascripts/common/bulk-actions.js
+++ b/app/assets/javascripts/common/bulk-actions.js
@@ -79,10 +79,10 @@ class BulkActions {
         return Object.assign({}, modelElement.dataset)
       })
 
-    if(!BulkActions._handlers[triggerData.behavior])
-      throw new Error(`Missing handler for ${ triggerData.behavior }`)
+    if(!BulkActions.handlers[triggerData.behavior])
+      throw new Error(`Missing handler for ${ triggerData.behavior } - ${JSON.stringify(BulkActions.handlers)}`)
 
-    BulkActions._handlers[triggerData.behavior](triggerData, modelData)
+    BulkActions.handlers[triggerData.behavior](triggerData, modelData)
   }
 
   static registerHandlerFor(behavior, handler) {

--- a/app/assets/javascripts/common/modals.js
+++ b/app/assets/javascripts/common/modals.js
@@ -5,9 +5,14 @@ class AutomaticallyWiredModals {
   get _modalTriggers() { return $("[data-behavior~=neomodal]") }
 
   handleModalTriggerClick(event) {
+    event.preventDefault()
+
     const dataset = event.target.dataset
 
     const storageTarget = document.getElementById(dataset.storage)
+
+    if(!storageTarget)
+      throw new Error(`storage target #${dataset.storage} must exist on page. are you missing a #model_tag call?`)
 
     const templateData = {
       modal: _.omit(dataset, "behavior", "template", "storage"),

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -120,10 +120,10 @@ module ApplicationHelper
 
     options = {
       data: JSON.parse(data.to_json),
-      class: "clickable item"
+      class: "clickable ui item"
     }.merge opts.slice(:id, :class)
 
-    tag.div(**options, &block)
+    tag.a(**options, &block)
   end
   # rubocop:enable Metrics/AbcSize
 

--- a/app/views/bookmarks/show.html.haml
+++ b/app/views/bookmarks/show.html.haml
@@ -1,8 +1,6 @@
 - content_for :page_title do
   Bookmark '#{ @bookmark.title }'
 
-= model_tag @bookmark, only: [ :uri, :title ], no_checkbox: true
-
 - content_for :secondary_navbar do
   - if @bookmark.offline_caches.any?
     = link_to "offline cache", bookmark_cache_index_path(@bookmark), data: { turbolinks: false }, class: "ui item"
@@ -22,6 +20,8 @@
       delete
 
 - content_for :custom_grid do
+  = model_tag @bookmark, only: [ :uri, :title ], no_checkbox: true
+
   .ui.fluid.horizontally.padded.stackable.grid
     .eight.wide.column
       %h2.ui.header


### PR DESCRIPTION
This fixes two bugs:
* Unable to delete a single bookmark when viewing it
* Random failures to open modals, with the console logging ``Missing handler for <behavior>`

And includes a stylistic update to ensure the delete button and other modal buttons look and behave like buttons in the navbar.