### PR TITLE
Update the oauth authorize view to be more informative

### DIFF
--- a/app/controllers/oauth/authorizations_controller.rb
+++ b/app/controllers/oauth/authorizations_controller.rb
@@ -4,16 +4,11 @@ class Oauth::AuthorizationsController < ApplicationController
   include Doorkeeper::Helpers::Controller
 
   def new
-    if pre_auth.authorizable?
-      if skip_authorization? || matching_token?
-        auth = authorization.authorize
-        redirect_to auth.redirect_uri
-      else
-        render :new
-      end
-    else
-      render :error
-    end
+    return render :error unless pre_auth.authorizable?
+    return render :new unless skip_authorization? || matching_token?
+
+    auth = authorization.authorize
+    redirect_to auth.redirect_uri
   end
 
   # TODO: Handle raise invalid authorization

--- a/app/views/oauth/authorizations/new.html.haml
+++ b/app/views/oauth/authorizations/new.html.haml
@@ -1,9 +1,9 @@
 - content_for :page_title do
   Authorize "#{ @pre_auth.client.name }"
 
-.ui.grid
-  .row
-    .centered.six.wide.column
+.ui.stackable.center.aligned.grid
+  .ui.middle.aligned.row
+    .six.wide.column
       .ui.segment
         %h3.ui.header
           .content

--- a/app/views/oauth/authorizations/new.html.haml
+++ b/app/views/oauth/authorizations/new.html.haml
@@ -4,36 +4,59 @@
 .ui.grid
   .row
     .centered.six.wide.column
-      %h2.ui.header Authorization required
+      .ui.segment
+        %h3.ui.header
+          .content
+            %code= @pre_auth.client.application.name
+            By #{ @pre_auth.client.application.owner.username }
+            .sub.header
+              Would like to access your transientBug account
 
-      %p
-        Authorize this application
-        %code= @pre_auth.client.name
-        to access your data?
+        %p
+          This application will have access to create, update, delete and view all your stored bookmarks.
 
-      - if @pre_auth.scopes.count > 0
-        %p This application will be able to:
+        - if @pre_auth.scopes.count > 0
+          %p This application will be able to:
 
-        %ul.ui.list
-          - @pre_auth.scopes.each do |scope|
-            %li.item= scope
+          %ul.ui.list
+            - @pre_auth.scopes.each do |scope|
+              %li.item= scope
 
-      .ui.grid
-        .equal.width.row
-          .column
-            = form_tag oauth_authorization_path, method: :post do
-              = hidden_field_tag :client_id, @pre_auth.client.uid
-              = hidden_field_tag :redirect_uri, @pre_auth.redirect_uri
-              = hidden_field_tag :state, @pre_auth.state
-              = hidden_field_tag :response_type, @pre_auth.response_type
-              = hidden_field_tag :scope, @pre_auth.scope
-              = submit_tag "Authorize", class: "ui huge positive button"
+        = form_tag oauth_authorization_path, method: :post do
+          = hidden_field_tag :client_id, @pre_auth.client.uid
+          = hidden_field_tag :redirect_uri, @pre_auth.redirect_uri
+          = hidden_field_tag :state, @pre_auth.state
+          = hidden_field_tag :response_type, @pre_auth.response_type
+          = hidden_field_tag :scope, @pre_auth.scope
+          = submit_tag "Authorize", class: "ui fluid positive button"
 
-          .column
-            = form_tag oauth_authorization_path, method: :delete do
-              = hidden_field_tag :client_id, @pre_auth.client.uid
-              = hidden_field_tag :redirect_uri, @pre_auth.redirect_uri
-              = hidden_field_tag :state, @pre_auth.state
-              = hidden_field_tag :response_type, @pre_auth.response_type
-              = hidden_field_tag :scope, @pre_auth.scope
-              = submit_tag "Deny", class: "ui huge negative button"
+        %small
+          Authorizing will redirect you back to the application.
+          %br
+          You can revoke access to this app at anytime from the
+          = link_to "authorized apps page", oauth_authorized_applications_url
+          in your account settings.
+
+      .ui.segment
+        .ui.three.column.stackable.center.aligned.grid
+          .ui.middle.aligned.row
+            .column
+              %small
+                - if @pre_auth.client.application.official
+                  %i.green.checked.icon
+                  Owned and operated by the transientBug team
+                - else
+                  %i.ban.icon
+                  %strong Not
+                  owned or operated by the transientBug team
+            .column
+              %small
+                %i.clock.icon
+                Created
+                %strong= time_ago_in_words(@pre_auth.client.application.created_at)
+                ago
+            .column
+              %small
+                = link_to "https://oauth.net/2/" do
+                  %i.external.link.icon
+                  Learn about OAuth

--- a/app/views/oauth/authorized_applications/index.html.haml
+++ b/app/views/oauth/authorized_applications/index.html.haml
@@ -22,7 +22,7 @@
     - if @applications.any?
       - @applications.each do |application|
         %tr
-          %td.collapsing= model_tag application, only: [:name]
+          %td.collapsing= model_tag application, only: [:id, :name]
           %td.collapsing
             .ui.buttons
               = modal_tag application, :revoke, url: oauth_authorized_application_path(application), class: "ui icon button" do

--- a/db/migrate/20181204152019_add_official_to_oauth_applications.rb
+++ b/db/migrate/20181204152019_add_official_to_oauth_applications.rb
@@ -1,0 +1,5 @@
+class AddOfficialToOauthApplications < ActiveRecord::Migration[5.2]
+  def change
+    add_column :oauth_applications, :official, :boolean, default: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -557,7 +557,8 @@ CREATE TABLE oauth_applications (
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     owner_id integer,
-    owner_type character varying
+    owner_type character varying,
+    official boolean DEFAULT false
 );
 
 
@@ -1496,6 +1497,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20180212151435'),
 ('20180214183218'),
 ('20180223222455'),
-('20180620161718');
+('20180620161718'),
+('20181204152019');
 
 


### PR DESCRIPTION
In line with getting ready for a new major version of the browser extension, this reworks the oauth authorize view to be a bit better and clearer, along with adding a new "Official" column on applications. In a future PR I'll add in the admin views for managing all applications, including marking applications as official.

This view is mostly modeled off of githubs oauth page, as seen in this [trello card](https://trello.com/c/NSycKRpZ/36-better-design-of-oauth2-authorize-page)

Standard desktop view:
![authorizations - vim1 2018-12-05 11-27-24](https://user-images.githubusercontent.com/94542/49535175-c1756a00-f880-11e8-8db2-ae031216bfc7.png)

Mobile view:
![transientbug authorize asdf 2018-12-05 11-26-36](https://user-images.githubusercontent.com/94542/49535159-b4f11180-f880-11e8-9df9-cb803f03b740.png)