### PR TITLE
security gem updates, remove bootstrap from package.json

### DIFF
--- a/.rubocop_rspec.yml
+++ b/.rubocop_rspec.yml
@@ -86,3 +86,6 @@ RSpec/NestedGroups:
 RSpec/NotToNot:
   Description: Checks for consistent method usage for negating expectations.
   Enabled: true
+
+FactoryBot/StaticAttributeDefinedDynamically:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ git_source(:github) do |repo_name|
 end
 
 # Base Rails stuff
-gem "rails", "~> 5.2"
+gem "rails", "~> 5.2.1.1"
 
 # Data Stores
 #  * Postgres
@@ -103,6 +103,11 @@ gem "parslet"
 # API Documentation from RAD
 gem "apitome"
 
+# Security issues
+gem "rubyzip", ">= 1.2.2"
+gem "rack", ">= 2.0.6"
+gem "loofah", ">= 2.2.3"
+
 group :development do
   # Access an IRB console on exception pages or by using <%= console %> anywhere in the code.
   gem "web-console", ">= 3.3.0"
@@ -144,7 +149,7 @@ group :development, :test do
 
   # Document the API through rspec tests
   gem "rspec_api_documentation"
-  gem "json_matchers"
+  gem "json_matchers", "~> 0.9"
 
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   # gem "spring"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,25 +9,25 @@ GEM
   remote: https://rubygems.org/
   remote: https://rails-assets.org/
   specs:
-    actioncable (5.2.0)
-      actionpack (= 5.2.0)
+    actioncable (5.2.1.1)
+      actionpack (= 5.2.1.1)
       nio4r (~> 2.0)
       websocket-driver (>= 0.6.1)
-    actionmailer (5.2.0)
-      actionpack (= 5.2.0)
-      actionview (= 5.2.0)
-      activejob (= 5.2.0)
+    actionmailer (5.2.1.1)
+      actionpack (= 5.2.1.1)
+      actionview (= 5.2.1.1)
+      activejob (= 5.2.1.1)
       mail (~> 2.5, >= 2.5.4)
       rails-dom-testing (~> 2.0)
-    actionpack (5.2.0)
-      actionview (= 5.2.0)
-      activesupport (= 5.2.0)
+    actionpack (5.2.1.1)
+      actionview (= 5.2.1.1)
+      activesupport (= 5.2.1.1)
       rack (~> 2.0)
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
-    actionview (5.2.0)
-      activesupport (= 5.2.0)
+    actionview (5.2.1.1)
+      activesupport (= 5.2.1.1)
       builder (~> 3.1)
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
@@ -35,20 +35,20 @@ GEM
     active_link_to (1.0.5)
       actionpack
       addressable
-    activejob (5.2.0)
-      activesupport (= 5.2.0)
+    activejob (5.2.1.1)
+      activesupport (= 5.2.1.1)
       globalid (>= 0.3.6)
-    activemodel (5.2.0)
-      activesupport (= 5.2.0)
-    activerecord (5.2.0)
-      activemodel (= 5.2.0)
-      activesupport (= 5.2.0)
+    activemodel (5.2.1.1)
+      activesupport (= 5.2.1.1)
+    activerecord (5.2.1.1)
+      activemodel (= 5.2.1.1)
+      activesupport (= 5.2.1.1)
       arel (>= 9.0)
-    activestorage (5.2.0)
-      actionpack (= 5.2.0)
-      activerecord (= 5.2.0)
+    activestorage (5.2.1.1)
+      actionpack (= 5.2.1.1)
+      activerecord (= 5.2.1.1)
       marcel (~> 0.3.1)
-    activesupport (5.2.0)
+    activesupport (5.2.1.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -96,7 +96,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    concurrent-ruby (1.0.5)
+    concurrent-ruby (1.1.3)
     connection_pool (2.2.2)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
@@ -192,7 +192,7 @@ GEM
     http_parser.rb (0.6.0)
     httparty (0.16.2)
       multi_xml (>= 0.5.2)
-    i18n (1.1.0)
+    i18n (1.1.1)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.1)
     jbuilder (2.7.0)
@@ -225,11 +225,11 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
-    loofah (2.2.2)
+    loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     lumberjack (1.0.13)
-    mail (2.7.0)
+    mail (2.7.1)
       mini_mime (>= 0.1.1)
     mailcatcher (0.2.4)
       eventmachine
@@ -241,11 +241,11 @@ GEM
       skinny (>= 0.1.2)
       sqlite3-ruby
       thin
-    marcel (0.3.2)
+    marcel (0.3.3)
       mimemagic (~> 0.3.2)
-    method_source (0.9.0)
+    method_source (0.9.2)
     mimemagic (0.3.2)
-    mini_mime (1.0.0)
+    mini_mime (1.0.1)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
     multi_json (1.13.1)
@@ -255,7 +255,7 @@ GEM
     mustermann (1.0.2)
     nenv (0.3.0)
     nio4r (2.3.1)
-    nokogiri (1.8.4)
+    nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
@@ -312,7 +312,7 @@ GEM
       pry (>= 0.10.4)
     public_suffix (3.0.2)
     puma (3.11.4)
-    rack (2.0.5)
+    rack (2.0.6)
     rack-cache (1.8.0)
       rack (>= 0.4)
     rack-cors (1.0.2)
@@ -322,18 +322,18 @@ GEM
       rack
     rack-test (0.7.0)
       rack (>= 1.0, < 3)
-    rails (5.2.0)
-      actioncable (= 5.2.0)
-      actionmailer (= 5.2.0)
-      actionpack (= 5.2.0)
-      actionview (= 5.2.0)
-      activejob (= 5.2.0)
-      activemodel (= 5.2.0)
-      activerecord (= 5.2.0)
-      activestorage (= 5.2.0)
-      activesupport (= 5.2.0)
+    rails (5.2.1.1)
+      actioncable (= 5.2.1.1)
+      actionmailer (= 5.2.1.1)
+      actionpack (= 5.2.1.1)
+      actionview (= 5.2.1.1)
+      activejob (= 5.2.1.1)
+      activemodel (= 5.2.1.1)
+      activerecord (= 5.2.1.1)
+      activestorage (= 5.2.1.1)
+      activesupport (= 5.2.1.1)
       bundler (>= 1.3.0)
-      railties (= 5.2.0)
+      railties (= 5.2.1.1)
       sprockets-rails (>= 2.0.0)
     rails-assets-lodash (4.17.10)
     rails-dom-testing (2.0.3)
@@ -341,12 +341,12 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.0.4)
       loofah (~> 2.2, >= 2.2.2)
-    railties (5.2.0)
-      actionpack (= 5.2.0)
-      activesupport (= 5.2.0)
+    railties (5.2.1.1)
+      actionpack (= 5.2.1.1)
+      activesupport (= 5.2.1.1)
       method_source
       rake (>= 0.8.7)
-      thor (>= 0.18.1, < 2.0)
+      thor (>= 0.19.0, < 2.0)
     rainbow (2.2.2)
       rake
     rake (12.3.1)
@@ -412,7 +412,7 @@ GEM
     ruby_dep (1.5.0)
     ruby_parser (3.11.0)
       sexp_processor (~> 4.9)
-    rubyzip (1.2.1)
+    rubyzip (1.2.2)
     rugged (0.27.2)
     safe_yaml (1.0.4)
     sass (3.5.6)
@@ -542,9 +542,10 @@ DEPENDENCIES
   http
   jbuilder
   jquery-rails
-  json_matchers
+  json_matchers (~> 0.9)
   kaminari
   listen (>= 3.0.5, < 3.2)
+  loofah (>= 2.2.3)
   mailcatcher
   mimemagic
   mustermann
@@ -560,9 +561,10 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   pundit!
+  rack (>= 2.0.6)
   rack-cors
   rack-test (~> 0.7.0)
-  rails (~> 5.2)
+  rails (~> 5.2.1.1)
   rails-assets-lodash!
   redis (~> 3.0)
   redis-rack-cache
@@ -572,6 +574,7 @@ DEPENDENCIES
   rspec_api_documentation
   rubocop
   rubocop-rspec
+  rubyzip (>= 1.2.2)
   sass-rails (~> 5.0)
   selenium-webdriver
   semantic-ui-sass (~> 2.2.12.0)

--- a/app/controllers/oauth/authorized_applications/bulk/revokes_controller.rb
+++ b/app/controllers/oauth/authorized_applications/bulk/revokes_controller.rb
@@ -3,7 +3,7 @@ class Oauth::AuthorizedApplications::Bulk::RevokesController < ApplicationContro
 
   # DELETE /oauth/authorized_applications/bulk/revoke
   def destroy
-    results = Doorkeeper::AccessToken.revoke_all_for bulk_params[:ids], current_user
+    results = Doorkeeper::AccessToken.authorized_tokens_for(bulk_params[:ids], current_user).each(&:revoke)
 
     revoke_results = results.each_with_object({}) do |access_token, memo|
       memo[ access_token.application_id ] = access_token.revoked_at

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -51,7 +51,7 @@ module ApplicationHelper
   # A bulk select checkbox, used to find which rows are effected by the bulk
   # action being performed.
   def bulk_edit_checkbox model
-    tag_id = "select-#{ model.class.to_s.underscore }-data-#{ model.id }"
+    tag_id = sanitize_to_id("select-#{ model.class.to_s.underscore }-data-#{ model.id }")
 
     tag.div(class: "ui checkbox") do
       capture do
@@ -88,7 +88,7 @@ module ApplicationHelper
 
     options = {
       class: "hidden model-data",
-      id: "#{ model.class.to_s.underscore }-data-#{ model.id }",
+      id: sanitize_to_id("#{ model.class.to_s.underscore }-data-#{ model.id }"),
       data: data
     }.merge opts
 
@@ -115,7 +115,7 @@ module ApplicationHelper
     data = {
       behavior: "neomodal",
       template: template,
-      storage: "#{ model.class.to_s.underscore }-data-#{ model.id }"
+      storage: sanitize_to_id("#{ model.class.to_s.underscore }-data-#{ model.id }")
     }.merge opts.except(:id, :class)
 
     options = {
@@ -138,5 +138,13 @@ module ApplicationHelper
       "templates",
       current_controller
     ].concat(args).flatten.compact.join "/"
+  end
+
+  # Copy and pasted from Rails's actionview/lib/action_view/helpers/form_tag_helper.rb
+  # since the form builders do this but the method is private and
+  # not-opt-outable which is causing issues with tag ids that have slashes in
+  # them, getting sanitized in checkboxes
+  def sanitize_to_id name
+    name.to_s.delete("]").tr("^-a-zA-Z0-9:.", "_")
   end
 end

--- a/db/migrate/20181205204805_add_confidential_to_applications.rb
+++ b/db/migrate/20181205204805_add_confidential_to_applications.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+class AddConfidentialToApplications < ActiveRecord::Migration[5.2]
+  def change
+    # the original migration defaults to true for confidential, however as per
+    # https://tools.ietf.org/html/draft-ietf-oauth-native-apps-12
+    # the apps that are shared amoung others are not secret or confidential.
+    # since this is the default use case for tb's oauth, and to continue having
+    # apps function, this was changed to default to false.
+    add_column(
+      :oauth_applications,
+      :confidential,
+      :boolean,
+      null: false,
+      default: false
+    )
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -558,7 +558,8 @@ CREATE TABLE oauth_applications (
     updated_at timestamp without time zone NOT NULL,
     owner_id integer,
     owner_type character varying,
-    official boolean DEFAULT false
+    official boolean DEFAULT false,
+    confidential boolean DEFAULT false NOT NULL
 );
 
 
@@ -1498,6 +1499,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20180214183218'),
 ('20180223222455'),
 ('20180620161718'),
-('20181204152019');
+('20181204152019'),
+('20181205204805');
 
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "babel-polyfill": "^6.23.0",
     "babel-preset-env": "^1.6.0",
     "babel-preset-react": "^6.24.1",
-    "bootstrap": "^3.3.7",
     "coffee-loader": "^0.7.3",
     "coffee-script": "^1.12.7",
     "compression-webpack-plugin": "^1.0.0",

--- a/spec/factories/bookmark.rb
+++ b/spec/factories/bookmark.rb
@@ -3,11 +3,11 @@ FactoryBot.define do
     user
     webpage
 
-    title "test"
+    title { "test" }
 
     factory :bookmark_with_tags do
       transient do
-        tags_count 2
+        tags_count { 2 }
       end
 
       after(:create) do |bookmark, evaluator|

--- a/spec/factories/error_messages.rb
+++ b/spec/factories/error_messages.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :error_message do
-    key "MyString"
-    message "MyText"
+    key { "MyString" }
+    message { "MyText" }
   end
 end

--- a/spec/factories/import_data.rb
+++ b/spec/factories/import_data.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :import_datum, class: "ImportData" do
-    user nil
-    import_type ""
+    user { nil }
+    import_type { "" }
   end
 end

--- a/spec/factories/offline_caches.rb
+++ b/spec/factories/offline_caches.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :offline_cach, class: "OfflineCache" do
-    bookmark nil
-    document_id nil
+    bookmark { nil }
+    document_id { nil }
   end
 end

--- a/spec/factories/searches.rb
+++ b/spec/factories/searches.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :search do
-    user nil
-    name "MyString"
-    description "MyText"
-    query "MyText"
+    user { nil }
+    name { "MyString" }
+    description { "MyText" }
+    query { "MyText" }
   end
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -3,12 +3,12 @@ FactoryBot.define do
     sequence(:username) { |n| "person#{ n }" }
     sequence(:email) { |n| "person#{ n }@example.com" }
 
-    password "12345"
+    password { "12345" }
     password_confirmation { password }
 
     trait :with_role do
       transient do
-        role_names [ :default ]
+        role_names { [ :default ] }
       end
 
       after(:create) do |user, evaluator|


### PR DESCRIPTION
Also had to fix a breaking change introduced in `Doorkeeper::AccessToken.revoke_all_for` which changed the return from an array of the models to a number representing the number of rows updated.