### PR TITLE
enqueue the caching bookmark job only after the record is saved to the DB

### DIFF
--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -6,7 +6,7 @@ class Bookmark < ApplicationRecord
 
   has_and_belongs_to_many :offline_caches
 
-  after_create :schedule_cache
+  after_commit :schedule_cache, on: :create
 
   default_scope { includes(:webpage) }
 


### PR DESCRIPTION
tl;dr - Bookmarks sometimes weren't cached as the jobs were failing with things like:
```
D, [2019-05-29T17:38:17.635586 #1] DEBUG -- : Failed to find parameters
D, [2019-05-29T17:38:17.635685 #1] DEBUG -- : Error while trying to deserialize arguments: Couldn't find Bookmark with 'id'=1193
2019-05-29T17:38:17.635Z 1 TID-gryqlfqg5 WebpageCacheJob JID-7657e2b5a75eb4855b72d8a4 INFO: done: 0.004 sec
```
Which were because the jobs were enqueued before the DB transaction completed, breaking the guaruntee that the record would be available to the job.

TIL of after_commit and this should solve all the bookmarks not being cached.

In addition to the coming admin search that will enable me to find all bookmarks that are uncached I should be able to clean this all up and get caches caught up so all bookmarks have at least attempts.