### PR TITLE
try out a before_install for bundler because the travis image keeps failing on missing bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,9 @@ env:
     - ES_DOWNLOAD_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz
     - PULL_REQUEST_ID=$TRAVIS_PULL_REQUEST
 
-before_install: gem install bundler
+before_install:
+  - gem update --system
+  - gem install bundler
 
 jobs:
   include:


### PR DESCRIPTION
Seems that travis has changed something about their images for ruby 2.5 which is causing the builds to now fail because bundler isn't installed. This is copy-pasta out of their [docs](https://docs.travis-ci.com/user/languages/ruby/#bundler-20) so hopefully, it works `ಠ_ಠ`