### PR TITLE
move to a has_many through relation for tags on bookmarks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,13 +6,15 @@ AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
   Include:
-    - "**/*.rb"
+    - '**/*.rb'
     - '**/Rakefile'
   Exclude:
-    - bin/*
+    - 'db/**/*'
+    - 'config/**/*'
+    - 'script/**/*'
+    - 'bin/*'
+    - 'storage/**/*'
     - node_modules/**/* # why the fuck is rubocop running against node_modules
-    - db/migrate/*
-    - db/schema.rb
     - vendor/**/* # disable rubocop-ing the gem install path in travis
 
 # Configuration parameters: Include, TreatCommentsAsGroupSeparators.

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -2,7 +2,8 @@ class Bookmark < ApplicationRecord
   belongs_to :user
   belongs_to :webpage
 
-  has_and_belongs_to_many :tags
+  has_many :bookmarks_tags
+  has_many :tags, through: :bookmarks_tags
 
   has_and_belongs_to_many :offline_caches
 

--- a/app/models/bookmarks_tag.rb
+++ b/app/models/bookmarks_tag.rb
@@ -2,5 +2,5 @@ class BookmarksTag < ApplicationRecord
   belongs_to :bookmark
   belongs_to :tag
 
-  update_index("bookmarks#bookmark") { self.bookmark }
+  update_index("bookmarks#bookmark") { bookmark }
 end

--- a/app/models/bookmarks_tag.rb
+++ b/app/models/bookmarks_tag.rb
@@ -1,0 +1,6 @@
+class BookmarksTag < ApplicationRecord
+  belongs_to :bookmark
+  belongs_to :tag
+
+  update_index("bookmarks#bookmark") { self.bookmark }
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -23,7 +23,7 @@ class Tag < ApplicationRecord
   has_many :bookmarks, through: :bookmarks_tags
 
   update_index("bookmarks#tag") { self }
-  update_index("bookmarks#bookmark") { self.bookmarks }
+  update_index("bookmarks#bookmark") { bookmarks }
 
   def self.find_or_create_tags tags: []
     tags.map do |tag|

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -19,7 +19,11 @@ class Tag < ApplicationRecord
 
   validates :label, presence: true, uniqueness: true
 
+  has_many :bookmarks_tags
+  has_many :bookmarks, through: :bookmarks_tags
+
   update_index("bookmarks#tag") { self }
+  update_index("bookmarks#bookmark") { self.bookmarks }
 
   def self.find_or_create_tags tags: []
     tags.map do |tag|

--- a/db/migrate/20190605150347_add_pk_to_bookmarks_tags.rb
+++ b/db/migrate/20190605150347_add_pk_to_bookmarks_tags.rb
@@ -1,0 +1,5 @@
+class AddPkToBookmarksTags < ActiveRecord::Migration[5.2]
+  def change
+    add_column :bookmarks_tags, :id, :primary_key
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -244,8 +244,28 @@ CREATE TABLE bookmarks_offline_caches (
 
 CREATE TABLE bookmarks_tags (
     bookmark_id bigint NOT NULL,
-    tag_id bigint NOT NULL
+    tag_id bigint NOT NULL,
+    id bigint NOT NULL
 );
+
+
+--
+-- Name: bookmarks_tags_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE bookmarks_tags_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: bookmarks_tags_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE bookmarks_tags_id_seq OWNED BY bookmarks_tags.id;
 
 
 --
@@ -867,6 +887,13 @@ ALTER TABLE ONLY bookmarks ALTER COLUMN id SET DEFAULT nextval('bookmarks_id_seq
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
+ALTER TABLE ONLY bookmarks_tags ALTER COLUMN id SET DEFAULT nextval('bookmarks_tags_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY clockwork_database_events ALTER COLUMN id SET DEFAULT nextval('clockwork_database_events_id_seq'::regclass);
 
 
@@ -1013,6 +1040,14 @@ ALTER TABLE ONLY authorizations
 
 ALTER TABLE ONLY bookmarks
     ADD CONSTRAINT bookmarks_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: bookmarks_tags_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY bookmarks_tags
+    ADD CONSTRAINT bookmarks_tags_pkey PRIMARY KEY (id);
 
 
 --
@@ -1500,6 +1535,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20180223222455'),
 ('20180620161718'),
 ('20181204152019'),
-('20181205204805');
+('20181205204805'),
+('20190605150347');
 
 

--- a/spec/factories/bookmarks_tags.rb
+++ b/spec/factories/bookmarks_tags.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :bookmarks_tag do
+    
+  end
+end

--- a/spec/factories/bookmarks_tags.rb
+++ b/spec/factories/bookmarks_tags.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :bookmarks_tag do
-    
   end
 end

--- a/spec/models/bookmarks_tag_spec.rb
+++ b/spec/models/bookmarks_tag_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe BookmarksTag, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/bookmarks_tag_spec.rb
+++ b/spec/models/bookmarks_tag_spec.rb
@@ -1,5 +1,5 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe BookmarksTag, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  pending "add some examples to (or delete) #{ __FILE__ }"
 end


### PR DESCRIPTION
this lets chewy sit on the bookmarkstags model and update the index when new entries are added
which addresses a bug in which bulk adding tags was not reindexing ES so searches for no tags,
for example, is returning newly tagged bookmarks still