### PR TITLE
Add in a basic bonjour service annoucement in development mode

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -151,9 +151,7 @@ group :development, :test do
   gem "rspec_api_documentation"
   gem "json_matchers", "~> 0.9"
 
-  # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
-  # gem "spring"
-  # gem "spring-watcher-listen", "~> 2.0.0"
+  gem "dnssd"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,7 @@ GEM
     database_cleaner (1.7.0)
     debug_inspector (0.0.3)
     diff-lcs (1.3)
+    dnssd (3.0.1)
     docile (1.3.1)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
@@ -495,6 +496,7 @@ DEPENDENCIES
   chewy
   connection_pool
   database_cleaner
+  dnssd
   doorkeeper
   dotenv-rails
   ejs

--- a/config/initializers/bonjour.rb
+++ b/config/initializers/bonjour.rb
@@ -1,0 +1,18 @@
+return if File.split($PROGRAM_NAME).last == 'rake'
+
+return if defined?(Rails::Console)
+return unless defined?(Rails::Server)
+
+hostname = "#{ `whoami`.strip }@#{ `hostname`.strip }"
+# host = Rails::Server.new.options[:Host] || 'localhost'
+port = Rails::Server.new.options[:Port] || ENV['PORT'] || 3000
+
+return unless Rails.env.development?
+
+require "dnssd"
+
+tr = DNSSD::TextRecord.new "service" => "transientBug-API"
+
+DNSSD.register hostname, "_http._tcp", "local", port.to_i, tr.encode do |register_reply|
+  puts "Bonjour registration: #{ register_reply.inspect }"
+end


### PR DESCRIPTION
The intention being that the extension can make use of this in development builds
to allow for some easier config of which API a dev build it pointing at. This does currently have the issue of not being able to properly get the host and port out of rails, the `Rails::Server.new.options` trick that I've used in the past is just returning an empty hash :/ Some more work is needed in that regard but otherwise the rest should be good to go.

With the node [bonjour] package, this shows up looking a bit like:
```javascript
[ { addresses:
     [ '192.168.86.29' ],
    rawTxt:
     <Buffer all the bytes>,
    txt:
     { service: 'transientBug-API',
       who: 'joshashby@hostname' },
    name: 'TB - hostname',
    fqdn: 'TB - hostname._http._tcp.local',
    host: 'hostname.local',
    referer:
     { address: '192.168.86.29',
       family: 'IPv4',
       port: 5353,
       size: 289 },
    port: 3000,
    type: 'http',
    protocol: 'tcp',
    subtypes: [] } ]
```

or with the `dns-sd` cli tool:
```
$ dns-sd -B _http._tcp .
Browsing for _http._tcp
DATE: ---Thu 06 Jun 2019---
16:14:12.081  ...STARTING...
Timestamp     A/R    Flags  if Domain               Service Type         Instance Name
16:14:48.778  Add        2   8 local.               _http._tcp.          joshashby@hostname
```