### PR TITLE
fix bug with bookmarks allowing null webpage_ids

### DIFF
--- a/app/controllers/api/v1/bookmarks_controller.rb
+++ b/app/controllers/api/v1/bookmarks_controller.rb
@@ -21,6 +21,8 @@ class Api::V1::BookmarksController < Api::V1Controller
     if @bookmark.upsert
       render :show, status: :created, location: @bookmark
     else
+      # TODO: these errors might not map directly 1-1 with the API surface
+      # (referencing webpage_id for example) and should be mapped
       render json: @bookmark.errors, status: :unprocessable_entity
     end
   end

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -16,6 +16,7 @@ class Bookmark < ApplicationRecord
   update_index("bookmarks#bookmark") { self }
 
   validates_uniqueness_of :webpage_id, scope: :user_id
+  validates :webpage_id, presence: true
 
   # This has potential performance costs if we start retrying lots of times
   def self.for user, uri


### PR DESCRIPTION
Addresses [this issue](https://trello.com/c/yXnJfqIa/80-api-doesnt-validate-url-is-present-when-creating-a-bookmark) where the API was allowing a bookmark to be created, which would then result in a 500 for the user on most bookmark related pages.

This bug did raise a concern with the API surface and how this error will be presented when the API doesn't expose the concept of a webpage model/resource. It got me thinking and I'm considering redesigning the API surface to be a bit more abstracted and address this issue with a proper solution.