### PR TITLE
fix issue with API not accepting uri; fix issue with dup tags in api

### DIFF
--- a/app/controllers/api/v1/bookmarks_controller.rb
+++ b/app/controllers/api/v1/bookmarks_controller.rb
@@ -63,9 +63,9 @@ class Api::V1::BookmarksController < Api::V1Controller
   # Tech Debt: Handle backwards compat where older clients may still be sending
   # url when the proper field is uri
   def uri_params
-    urlUri = params.require(:data).require(:attributes).permit(:url, :uri)
+    url_or_uri = params.require(:data).require(:attributes).permit(:url, :uri)
 
-    urlUri[:url] || urlUri[:uri]
+    url_or_uri[:url] || url_or_uri[:uri]
   end
 
   def tags_params

--- a/app/views/api/v1/bookmarks/_bookmark.json.jbuilder
+++ b/app/views/api/v1/bookmarks/_bookmark.json.jbuilder
@@ -4,6 +4,7 @@ json.id bookmark.id
 json.attributes do
   json.extract! bookmark, :title, :description, :created_at, :updated_at
   json.uri bookmark.uri.to_s
+  json.url bookmark.uri.to_s
 
   json.tags bookmark.tags.map(&:label)
 end

--- a/doc/api.md
+++ b/doc/api.md
@@ -94,3 +94,10 @@ to avoid storing your password.
 You can find your API token on your [profile](/profile) page. Through this page
 you can also regenerate your token, however this will invalidate your previous
 API token.
+
+
+## Changes
+
+### July, 2019
+As of late July, 2019 the Bookmarks create endpoint no longer overwrites
+existing bookmark data and will now respond with a 302 to the found bookmark.


### PR DESCRIPTION
Addresses [this issue](https://trello.com/c/wvYXVYg7/79-api-doesnt-dedup-tags) and [this issue](https://trello.com/c/POb3GjSI/81-api-responds-with-uri-instead-of-url) with the Bookmarks API in which duplicate `bookmarks_tags` entries could be created from an array of tags containing duplicate tag strings. It also adjusts the API to accept both `url` or `uri` and respond with both fields for backward compatibility. I think ideally I'd deprecate `url` in favor of `uri` later on or in an API rev.

Finally, this also addresses [this issue](https://trello.com/c/wlPHM5ts/66-saving-an-existing-site-overwrites-the-title) and changes the API to respond with a 302 when an existing bookmark has been found. This will not result in any of the bookmarks fields being updated, which is a breaking behavior, however, given that the flow for this endpoint is to find or create a bookmark when the extension popup first opens, this is the behavior I want and helps avoid overwriting the title when a bookmark exists.

![](https://http.cat/302)