### PR TITLE
remove omniauth for now to get around warnings about CVE-2015-9284

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,8 +71,10 @@ gem "sidekiq"
 # Provider
 gem "doorkeeper"
 # Consumer
-gem "omniauth-twitter"
-gem "omniauth-github"
+# gem "omniauth-rails_csrf_protection"
+# gem "omniauth-apple"
+# gem "omniauth-twitter"
+# gem "omniauth-github"
 
 # Permissions
 gem "pundit", github: "elabs/pundit"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,7 +164,6 @@ GEM
       html2haml (>= 1.0.1)
       railties (>= 4.0.1)
     hashdiff (0.3.7)
-    hashie (3.6.0)
     hiredis (0.6.1)
     html2haml (2.2.0)
       erubis (~> 2.7.0)
@@ -195,7 +194,6 @@ GEM
       addressable (>= 2.4)
     json_matchers (0.9.0)
       json-schema (~> 2.7)
-    jwt (1.5.6)
     kaminari (1.1.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.1.1)
@@ -238,7 +236,6 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.11.3)
     multi_json (1.13.1)
-    multi_xml (0.6.0)
     multipart-post (2.0.0)
     mustache (1.0.5)
     mustermann (1.0.2)
@@ -249,28 +246,6 @@ GEM
     notiffany (0.1.1)
       nenv (~> 0.1)
       shellany (~> 0.0)
-    oauth (0.5.4)
-    oauth2 (1.4.0)
-      faraday (>= 0.8, < 0.13)
-      jwt (~> 1.0)
-      multi_json (~> 1.3)
-      multi_xml (~> 0.5)
-      rack (>= 1.2, < 3)
-    omniauth (1.9.0)
-      hashie (>= 3.4.6, < 3.7.0)
-      rack (>= 1.6.2, < 3)
-    omniauth-github (1.3.0)
-      omniauth (~> 1.5)
-      omniauth-oauth2 (>= 1.4.0, < 2.0)
-    omniauth-oauth (1.1.0)
-      oauth
-      omniauth (~> 1.0)
-    omniauth-oauth2 (1.5.0)
-      oauth2 (~> 1.1)
-      omniauth (~> 1.2)
-    omniauth-twitter (1.4.0)
-      omniauth-oauth (~> 1.1)
-      rack
     parallel (1.12.1)
     parser (2.5.1.0)
       ast (~> 2.4.0)
@@ -518,8 +493,6 @@ DEPENDENCIES
   mailcatcher
   mimemagic
   nokogiri
-  omniauth-github
-  omniauth-twitter
   parslet
   pg
   pry

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,6 +1,0 @@
-Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :developer unless Rails.env.production?
-  # provider :twitter, ENV["TWITTER_KEY"], ENV["TWITTER_SECRET"]
-end
-
-OmniAuth.config.logger = Rails.logger


### PR DESCRIPTION
See [this thread](https://github.com/omniauth/omniauth/pull/809)

Omniauth isn't being used yet so let us remove it for now. I did add the rails csrf protection fork and a new [Sign in with Apple](https://github.com/nhosoya/omniauth-apple) gem commented out as a reminder to myself when I decide to de-private-alpha-tiz the service.