### PR TITLE
add clockwork

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,9 @@ gem "jbuilder"
 # ActiveJob Worker
 gem "sidekiq"
 
+# Cron like scheduled/repeating tasks
+gem "clockwork"
+
 # Auth
 # Provider
 gem "doorkeeper"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,8 @@ GEM
       elasticsearch-dsl
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
+    clockwork (2.0.3)
+      tzinfo
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
     connection_pool (2.2.2)
@@ -468,6 +470,7 @@ DEPENDENCIES
   capybara (~> 2.13)
   capybara-selenium
   chewy
+  clockwork
   connection_pool
   database_cleaner
   doorkeeper

--- a/Procfile
+++ b/Procfile
@@ -2,4 +2,5 @@ web: bundle exec rails s
 webpacker: ./bin/webpack-dev-server
 scssTypes: yarn watch-typings
 worker: bundle exec sidekiq
+cron: bundle exec clockwork clock.rb
 mail: mailcatcher -f


### PR DESCRIPTION
I've had a `clock.rb` file and a table for storing dynamic clockwork jobs in the repo for a while but not the gem. this adds the gem and adds it to the foreman procfile too.