### PR TITLE
stop a warning with eslint-react about react version

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,6 +26,15 @@ module.exports = {
     Rails: true,
   },
 
+  settings: {
+    "react": {
+      "createClass": "createReactClass", // Regex for Component Factory to use,
+                                         // default to "createReactClass"
+      "pragma": "React",  // Pragma to use, default to "React"
+      "version": "detect"
+    }
+  },
+
   overrides: [
     {
       files: ['**/*.ts', '**/*.tsx'],


### PR DESCRIPTION
To stop this warning when webpacker starts up:
```
16:44:47 webpacker.1 | Warning: React version not specified in eslint-plugin-react settings. See https://github.com/yannickcr/eslint-plugin-react#configuration .
```