### PR TITLE
return a 200 for found bookmarks in the API for the browser extension

### DIFF
--- a/app/controllers/api/v1/bookmarks_controller.rb
+++ b/app/controllers/api/v1/bookmarks_controller.rb
@@ -16,6 +16,9 @@ class Api::V1::BookmarksController < Api::V1Controller
     authorize @bookmark
 
     if @bookmark.id
+      # 302 Found with a location doesn't return CORS by default so things like
+      # a browser extension will fail on this request
+      response.set_header 'Access-Control-Allow-Origin', '*'
       render :show, status: :found, location: @bookmark
       return
     end

--- a/app/controllers/api/v1/bookmarks_controller.rb
+++ b/app/controllers/api/v1/bookmarks_controller.rb
@@ -16,10 +16,7 @@ class Api::V1::BookmarksController < Api::V1Controller
     authorize @bookmark
 
     if @bookmark.id
-      # 302 Found with a location doesn't return CORS by default so things like
-      # a browser extension will fail on this request
-      response.set_header 'Access-Control-Allow-Origin', '*'
-      render :show, status: :found, location: @bookmark
+      render :show, status: :ok, location: @bookmark
       return
     end
 


### PR DESCRIPTION
Status codes: never again. 302 FOUND is a bit of a misnomer in that the spec:

> The target resource resides temporarily under a different URI. Since the redirection might be altered on occasion, the client ought to continue to use the effective request URI for future requests.

states its for a temporary location, rather than the implied "i found an existing thing HERE" functionality I was looking for. CORS also doesn't work on 302s in the web extension, with fetch throwing a network error.
