### PR TITLE
turns out i still need redis-rails for session stores

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,9 +22,10 @@ gem "connection_pool"
 
 # gem "aws-sdk-s3", "~> 1"
 
-# TODO: Replace because of rails 5.2 having redis stores built in
-# gem "redis-rails"
-# gem "redis-rack-cache"
+# Caching - Rails 5.2 shipped with a redis cache for fragments, but doesn't
+# provide session storage via redis too, which redis-rails does.
+gem "redis-rails"
+gem "redis-rack-cache"
 
 # CORS
 gem "rack-cors"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -295,6 +295,8 @@ GEM
     puma (4.1.0)
       nio4r (~> 2.0)
     rack (2.0.7)
+    rack-cache (1.9.0)
+      rack (>= 0.4)
     rack-cors (1.0.3)
     rack-protection (2.0.5)
       rack
@@ -341,6 +343,25 @@ GEM
       railties (>= 3.2)
       tilt
     redis (4.1.2)
+    redis-actionpack (5.1.0)
+      actionpack (>= 4.0, < 7)
+      redis-rack (>= 1, < 3)
+      redis-store (>= 1.1.0, < 2)
+    redis-activesupport (5.2.0)
+      activesupport (>= 3, < 7)
+      redis-store (>= 1.3, < 2)
+    redis-rack (2.0.5)
+      rack (>= 1.5, < 3)
+      redis-store (>= 1.2, < 2)
+    redis-rack-cache (2.1.0)
+      rack-cache (>= 1.6, < 2)
+      redis-store (>= 1.6, < 2)
+    redis-rails (5.0.2)
+      redis-actionpack (>= 5.0, < 6)
+      redis-activesupport (>= 5.0, < 6)
+      redis-store (>= 1.2, < 2)
+    redis-store (1.6.0)
+      redis (>= 2.2, < 5)
     regexp_parser (1.6.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
@@ -522,6 +543,8 @@ DEPENDENCIES
   rake
   react-rails
   redis
+  redis-rack-cache
+  redis-rails
   rspec
   rspec-rails!
   rspec_api_documentation

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -55,13 +55,13 @@ Rails.application.configure do
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
-  config.cache_store = :redis_store, ENV["REDIS_URL"], { expires_in: 90.minutes }
+  config.cache_store = :redis_cache_store, { url: ENV["REDIS_URL"], expires_in: 90.minutes }
+
+  config.session_store :redis_store, servers: ["#{ ENV['REDIS_URL'] }/session"]
   config.action_dispatch.rack_cache = {
     metastore: "#{ ENV['REDIS_URL'] }/metastore",
     entitystore: "#{ ENV['REDIS_URL'] }/entitystore"
   }
-
-  config.session_store :redis_store, servers: ["#{ ENV['REDIS_URL'] }/session"]
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   config.active_job.queue_adapter = :sidekiq


### PR DESCRIPTION
Rails 5.2 introduced a redis store for fragment caching, so this switches over to that, however the redis-rails gem still provides a redis based session store, and a rack http cache.