### PR TITLE
Add a 'Tag Wizard' to step through and tag untagged bookmarks, o…

### DIFF
--- a/app/controllers/bookmarks/tag_wizard_controller.rb
+++ b/app/controllers/bookmarks/tag_wizard_controller.rb
@@ -36,6 +36,7 @@ class Bookmarks::TagWizardController < ApplicationController
 
   def set_bookmark
     @bookmark = Bookmark.find params[:id]
+
     authorize @bookmark
   end
 

--- a/app/controllers/bookmarks/tag_wizard_controller.rb
+++ b/app/controllers/bookmarks/tag_wizard_controller.rb
@@ -1,0 +1,52 @@
+class Bookmarks::TagWizardController < ApplicationController
+  require_login!
+  before_action :set_bookmark, only: [:update]
+
+  def index
+    scope = lambda do
+      includes(
+        :webpage,
+        :tags,
+        :user,
+        :offline_caches,
+      )
+    end
+
+    @bookmark = BookmarksSearcher.new.search('NOT has:tags')
+      .query(term: { user_id: current_user.id })
+      .per(1)
+      .load(scope: scope)
+      .objects.first
+
+    return render 'no_untagged' unless @bookmark
+
+    authorize @bookmark
+  end
+
+  def update
+    if bookmark_params[:tags].any? && @bookmark.update(bookmark_params)
+      redirect_to bookmarks_tag_wizard_index_path, notice: "Bookmark tagged!"
+    else
+      flash.notice = "You've got to add at least one tag to the bookmark, silly"
+      render :index
+    end
+  end
+
+  private
+
+  def set_bookmark
+    @bookmark = Bookmark.find params[:id]
+    authorize @bookmark
+  end
+
+  def bookmark_params
+    params.require(:bookmark).permit(:tags).tap do |obj|
+      tag_input = params.dig(:bookmark).fetch(:tags, [])
+      tag_input = tag_input.split(",") if tag_input.is_a? String
+
+      tags = Tag.find_or_create_tags tags: tag_input
+
+      obj.merge!(tags: tags)
+    end
+  end
+end

--- a/app/controllers/bookmarks/tag_wizard_controller.rb
+++ b/app/controllers/bookmarks/tag_wizard_controller.rb
@@ -8,17 +8,17 @@ class Bookmarks::TagWizardController < ApplicationController
         :webpage,
         :tags,
         :user,
-        :offline_caches,
+        :offline_caches
       )
     end
 
-    @bookmark = BookmarksSearcher.new.search('NOT has:tags')
+    @bookmark = BookmarksSearcher.new.search("NOT has:tags")
       .query(term: { user_id: current_user.id })
       .per(1)
       .load(scope: scope)
       .objects.first
 
-    return render 'no_untagged' unless @bookmark
+    return render "no_untagged" unless @bookmark
 
     authorize @bookmark
   end

--- a/app/views/bookmarks/tag_wizard/_form.html.haml
+++ b/app/views/bookmarks/tag_wizard/_form.html.haml
@@ -1,0 +1,16 @@
+= form_with model: bookmark, url: bookmarks_tag_wizard_path(bookmark), class: "ui fluid form", html: { autocomplete: "off" } do |f|
+  - if bookmark.errors.any?
+    .ui.message.error
+      %h2= "#{ pluralize bookmark.errors.count, "error" } prohibited this bookmark from being saved:"
+      %ul
+        - bookmark.errors.full_messages.each do |message|
+          %li= message
+
+  .field
+    = f.label :tags
+    .ui.multiple.search.selection.dropdown{ data: { behavior: "autocomplete-bookmark-tags" } }
+      = f.text_field :tags, value: bookmark.tags.map(&:label).join(","), style: "display: none", autocomplete: "off", data: { behaviour: "init" }
+      %i.dropdown.icon
+      .default.text Search Tags
+
+  = f.submit "Save & Next!", class: "ui positive fluid submit button"

--- a/app/views/bookmarks/tag_wizard/index.html.haml
+++ b/app/views/bookmarks/tag_wizard/index.html.haml
@@ -14,6 +14,8 @@
 - content_for :custom_grid do
   .ui.raised.very.padded.text.container.segment
     %h1.ui.header Tag Wizard!
+    %p
+      The tag wizard makes it easy for you to work through your backlog of untagged bookmarks!
 
     %h3.ui.header= @bookmark.title
 

--- a/app/views/bookmarks/tag_wizard/index.html.haml
+++ b/app/views/bookmarks/tag_wizard/index.html.haml
@@ -1,0 +1,34 @@
+- content_for :page_title do
+  Bookmark '#{ @bookmark.title }'
+
+- content_for :secondary_navbar do
+  - if @bookmark.offline_caches.any?
+    = link_to "offline cache", bookmark_cache_index_path(@bookmark), data: { turbolinks: false }, class: "ui item"
+
+  = link_to "edit", edit_bookmark_path(@bookmark), class: "ui item"
+
+  .right.menu
+    = modal_tag @bookmark, :delete, url: bookmark_path(@bookmark) do
+      delete
+
+- content_for :custom_grid do
+  .ui.container
+    %h1.ui.header Tag Wizard!
+
+    %h3.ui.header= @bookmark.title
+
+    = link_to @bookmark.uri.to_s, @bookmark.uri.to_s
+    .date
+      = @bookmark.created_at.to_s(:long)
+      UTC
+
+    %hr
+
+    = render partial: 'form', locals: { bookmark: @bookmark }
+
+    - if @bookmark.description.present?
+      %h3.ui.header Need a little more info?
+
+      %p
+        %strong Description:
+        = simple_format @bookmark.description

--- a/app/views/bookmarks/tag_wizard/index.html.haml
+++ b/app/views/bookmarks/tag_wizard/index.html.haml
@@ -12,7 +12,7 @@
       delete
 
 - content_for :custom_grid do
-  .ui.container
+  .ui.raised.very.padded.text.container.segment
     %h1.ui.header Tag Wizard!
 
     %h3.ui.header= @bookmark.title

--- a/app/views/bookmarks/tag_wizard/no_untagged.html.haml
+++ b/app/views/bookmarks/tag_wizard/no_untagged.html.haml
@@ -1,0 +1,13 @@
+- content_for :page_title do
+  Tag Wizard!
+
+- content_for :custom_grid do
+  .ui.fluid.horizontally.padded.stackable.grid
+    .four.wide.column
+    .six.wide.column
+      %h1.huge.center.aligned.icon.header
+        %i.bookmark.icon
+        .content No Untagged Bookmarks!
+
+      %p
+        Congrats, you don't have any untagged bookmarks currently!

--- a/app/views/dashboard/index.html.haml
+++ b/app/views/dashboard/index.html.haml
@@ -11,8 +11,11 @@
     - if @stats[:untagged_count] != 0
       .statistic.red
         .value= @stats[:untagged_count]
-        .label= link_to "Untagged Bookmarks", bookmarks_search_index_path(q: "NOT has:tags")
-    - else 
+        .label
+          = link_to "Untagged Bookmarks", bookmarks_search_index_path(q: "NOT has:tags")
+          %br
+          = link_to "Tag Wizard", bookmarks_tag_wizard_index_path, class: "ui mini button"
+    - else
       .statistic
         .value= @stats[:untagged_count]
         .label Untagged Bookmarks!

--- a/app/views/layouts/_head.html.haml
+++ b/app/views/layouts/_head.html.haml
@@ -8,6 +8,7 @@
   transientBug #{ content_for :page_title }
 
 = csrf_meta_tags
+= csp_meta_tag
 
 = stylesheet_link_tag "public", media: "all", "data-turbolinks-track": "reload"
 = stylesheet_pack_tag "public", media: "all", "data-turbolinks-track": "reload"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,6 +63,8 @@ Rails.application.routes.draw do
 
       collection do
         scope as: :bookmarks do
+          resources :tag_wizard, only: [:index, :update]
+
           resources :search, only: [:index]
 
           resources :tags, only: [:index, :show] do

--- a/spec/controllers/bookmarks/tag_wizard_controller_spec.rb
+++ b/spec/controllers/bookmarks/tag_wizard_controller_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Bookmarks::TagWizardController, type: :controller do
   let(:valid_attributes) do
     {
-      tags: 'test',
+      tags: "test"
     }
   end
 

--- a/spec/controllers/bookmarks/tag_wizard_controller_spec.rb
+++ b/spec/controllers/bookmarks/tag_wizard_controller_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe Bookmarks::TagWizardController, type: :controller do
+  let(:valid_attributes) do
+    {
+      tags: 'test',
+    }
+  end
+
+  let(:user) { create :user, :with_role, role_names: :admin }
+
+  let(:valid_session) do
+    {
+      user_id: user.id
+    }
+  end
+
+  let(:bookmark) { create :bookmark, tags: [], user_id: user.id }
+
+  before do
+    bookmark
+  end
+
+  describe "GET #index" do
+    it "returns http success" do
+      get :index, session: valid_session
+
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "POST #update" do
+    it "returns http success" do
+      post :update, params: { id: bookmark.id, bookmark: valid_attributes }, session: valid_session
+
+      expect(response).to redirect_to(bookmarks_tag_wizard_index_path)
+    end
+  end
+end

--- a/spec/views/bookmarks/tag_wizard/index.html.haml_spec.rb
+++ b/spec/views/bookmarks/tag_wizard/index.html.haml_spec.rb
@@ -1,5 +1,5 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe "tag_wizard/index.html.haml", type: :view do
-  pending "add some examples to (or delete) #{__FILE__}"
+  pending "add some examples to (or delete) #{ __FILE__ }"
 end

--- a/spec/views/bookmarks/tag_wizard/index.html.haml_spec.rb
+++ b/spec/views/bookmarks/tag_wizard/index.html.haml_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "tag_wizard/index.html.haml", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/bookmarks/tag_wizard/no_untagged.html.haml_spec.rb
+++ b/spec/views/bookmarks/tag_wizard/no_untagged.html.haml_spec.rb
@@ -1,5 +1,5 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe "tag_wizard/index.html.haml", type: :view do
-  pending "add some examples to (or delete) #{__FILE__}"
+  pending "add some examples to (or delete) #{ __FILE__ }"
 end

--- a/spec/views/bookmarks/tag_wizard/no_untagged.html.haml_spec.rb
+++ b/spec/views/bookmarks/tag_wizard/no_untagged.html.haml_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "tag_wizard/index.html.haml", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
This is another attempt/helper at getting my untagged bookmarks a little more organized by providing a single bookmark at a time to slowly work through.

![image](https://user-images.githubusercontent.com/94542/64827381-3d73af80-d581-11e9-8f9d-e1a6fbcb65bf.png)

The core functionality is done and ready to go, but the interface isn't quite at a spot that I want to push it out as a first pass.