### PR TITLE
CSP Refresh

### DIFF
--- a/app/controllers/csp_violation_report_controller.rb
+++ b/app/controllers/csp_violation_report_controller.rb
@@ -1,0 +1,19 @@
+class CspViolationReportController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
+  def create
+    Rails.logger.warn <<~MSG
+      CSP Violation
+
+      #{ csp_report }
+    MSG
+
+    head :ok
+  end
+
+  private
+
+  def csp_report
+    JSON.parse request.body.read
+  end
+end

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -22,17 +22,17 @@ Rails.application.config.content_security_policy do |policy|
   policy.font_src    :self, :https, :data, "fonts.gstatic.com"
   policy.img_src     :self, :https, :data
   policy.object_src  :none
-  policy.script_src  :self, :https, :unsafe_inline
-  policy.style_src   :self, :https, :unsafe_inline, "fonts.googleapis.com"
+  policy.script_src  :self, :https
+  policy.style_src   :self, :https, "fonts.googleapis.com"
 
   if Rails.env.development?
     policy.default_src :self, :https, "http://localhost:*", "ws://localhost:*", "http://localhost:8080"
-    policy.script_src  :self, :https, :unsafe_inline, :unsafe_eval, "http://localhost:*", "http://0.0.0.0:*"
+    policy.script_src  :self, :https, "http://localhost:*", "http://0.0.0.0:*"
     policy.connect_src :self, :https, "http://localhost:3035", "ws://localhost:3035"
   end
 
   # Specify URI for violation reports
-  # policy.report_uri  "/csp-violation-report-endpoint"
+  policy.report_uri  "/csp-violation-report"
 end
 
 # If you are using UJS then enable automatic nonce generation

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,6 +88,8 @@ Rails.application.routes.draw do
   match "/404", to: "errors#not_found", via: :all
   match "/500", to: "errors#internal_server_error", via: :all
 
+  resources :csp_violation_report, only: [:create], path: '/csp-violation-report', format: false, defaults: { format: :js }
+
   resources :images do
     collection do
       get "search"

--- a/spec/controllers/csp_violation_report_controller_spec.rb
+++ b/spec/controllers/csp_violation_report_controller_spec.rb
@@ -1,5 +1,19 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe CspViolationReportController, type: :controller do
+  let(:valid_attributes) do
+    {
+      "csp-violation": {}
+    }
+  end
 
+  let(:valid_session) do
+    {}
+  end
+
+  before do
+    post :create, body: JSON.dump(valid_attributes), session: valid_session
+  end
+
+  it { expect(response).to be_successful }
 end

--- a/spec/controllers/csp_violation_report_controller_spec.rb
+++ b/spec/controllers/csp_violation_report_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe CspViolationReportController, type: :controller do
+
+end


### PR DESCRIPTION
Production has some issues with the forms and CSP as a result of Rails 6 introducing nonce CSP which causes browser to ignore `inline` directives, so this adjusts the CSP config to better fit and hopefully work, while also introducing a CSP violation reporting endpoint that, for the time being, just logs the report out. I built the endpoint as a debugging tool, and am thinking I might expand it out to be similar to logster in functionality in the future, providing a web interface for seeing the reports and all.