### PR TITLE
Actions/Workflow for Rubocop & ESLint

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Set up Node 12.8
         uses: actions/setup-node@v1
         with:
-          ruby-version: 12.8.x
+          node-version: 12.8.x
 
       - name: Install libraries
         run: |

--- a/.github/workflows/styles.yml
+++ b/.github/workflows/styles.yml
@@ -1,0 +1,48 @@
+name: styles
+
+on:
+  pull_request:
+    branches:
+      - '*'
+  push:
+    branches:
+      - master
+
+jobs:
+  Rubocop:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Set up Ruby 2.6
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.6.x
+
+      - name: Install deps
+        run: |
+          gem install rubocop rubocop-rspec
+
+      - name: Run rubocop
+        run: |
+          rubocop
+
+  ESLint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Set up Node 12.8
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.8.x
+
+      - name: Install deps
+        run: |
+          yarn install
+
+      - name: Run eslint
+        run: |
+          yarn lint


### PR DESCRIPTION
This is the next step of replicating the travis setup to ideally turn it off, this should run eslint and rubocop on the repo.

ideally this turns into actions which add PR annotations for failures but I'll get to that later after getting the basic functionality of travis replicated.