### PR TITLE
Don't volume the assets for now

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ruby:2.6.3-alpine
 LABEL maintainer="Josh Ashby <me@joshisa.ninja>"
 
 WORKDIR /app
-VOLUME ["/app/public", "/dropzone"]
+VOLUME ["/dropzone"]
 
 RUN echo -e 'http://dl-cdn.alpinelinux.org/alpine/edge/main\nhttp://dl-cdn.alpinelinux.org/alpine/edge/community\nhttp://dl-cdn.alpinelinux.org/alpine/edge/testing' > /etc/apk/repositories && \
     apk add --no-cache build-base gcompat git curl postgresql-dev postgresql nodejs-current yarn && \


### PR DESCRIPTION
I have a problem where the new assets don't seem to make it into the new docker image and I suspect it might be because of the volume mounting at `/app/public`.