### PR TITLE
Remove inline styles to help make CSP happier

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -89,12 +89,9 @@ module ApplicationHelper
       data: data
     }.merge opts
 
-    display = "display: inline"
-    display = "display: none" if no_checkbox
-
     # Ensures that when we grab the siblings of the checkboxes that are
     # checked, that we'll end up with the correct div containing all the datas
-    tag.div style: display do
+    tag.div class: (no_checkbox ? "hidden" : "") do
       capture do
         concat tag.div(**options, &block)
         concat bulk_edit_checkbox model unless no_checkbox

--- a/app/views/bookmarks/_form.html.haml
+++ b/app/views/bookmarks/_form.html.haml
@@ -18,7 +18,7 @@
   .field
     = f.label :tags
     .ui.multiple.search.selection.dropdown{ data: { behavior: "autocomplete-bookmark-tags" } }
-      = f.text_field :tags, value: bookmark.tags.map(&:label).join(","), style: "display: none", autocomplete: "off", data: { behaviour: "init" }
+      = f.text_field :tags, value: bookmark.tags.map(&:label).join(","), autocomplete: "off", data: { behaviour: "init" }, class: "hidden"
       %i.dropdown.icon
       .default.text Search Tags
 

--- a/app/views/bookmarks/search/index.html.haml
+++ b/app/views/bookmarks/search/index.html.haml
@@ -3,7 +3,7 @@
 
 .ui.search.mobile.only
   .ui.fluid.icon.input
-    = form_tag bookmarks_search_index_path, method: :get, style: "display: flex; flex: auto;" do
+    = form_tag bookmarks_search_index_path, method: :get do
       = search_field_tag "q", params[:q], class: "ui prompt", placeholder: "Search Bookmarks ...", aria: { label: "search" }
     %i.search.icon
 

--- a/app/views/bookmarks/show.html.haml
+++ b/app/views/bookmarks/show.html.haml
@@ -7,7 +7,7 @@
 
   = link_to "edit", edit_bookmark_path(@bookmark), class: "ui item"
 
-  .ui.item{ style: "padding: 0px;" }
+  .ui.item
     .ui.small.labels
       - @bookmark.tags.each do |tag|
         = link_to bookmarks_tag_path(tag) do

--- a/app/views/bookmarks/tag_wizard/_form.html.haml
+++ b/app/views/bookmarks/tag_wizard/_form.html.haml
@@ -9,7 +9,7 @@
   .field
     = f.label :tags
     .ui.multiple.search.selection.dropdown{ data: { behavior: "autocomplete-bookmark-tags" } }
-      = f.text_field :tags, value: bookmark.tags.map(&:label).join(","), style: "display: none", autocomplete: "off", data: { behaviour: "init" }
+      = f.text_field :tags, value: bookmark.tags.map(&:label).join(","), autocomplete: "off", data: { behaviour: "init" }, class: "hidden"
       %i.dropdown.icon
       .default.text Search Tags
 

--- a/app/views/images/_form.html.haml
+++ b/app/views/images/_form.html.haml
@@ -13,7 +13,7 @@
   .field
     = f.label :tags
     .ui.multiple.search.selection.dropdown{ data: { behavior: "autocomplete-image-tags" } }
-      = f.text_field :tags, value: image.tags.join(","), style: "display: none", autocomplete: "off", data: { behaviour: "init" }
+      = f.text_field :tags, value: image.tags.join(","), autocomplete: "off", data: { behaviour: "init" }, class: "hidden"
       %i.dropdown.icon
       .default.text Search Tags
 

--- a/app/views/images/show.html.haml
+++ b/app/views/images/show.html.haml
@@ -19,7 +19,7 @@
   - if policy(@image).update?
     = link_to "edit", edit_image_path(@image), class: "ui item"
 
-  .ui.item{ style: "padding: 0px;" }
+  .ui.item
     .ui.small.labels
       - @image.tags.each do |tag|
         = link_to tag_images_path(tag) do


### PR DESCRIPTION
[Nonce](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src#Sources) CSP makes it a little harder for "anonymous" inline styles so far as I can find, so lets remove them to clean up the CSP logs and get ready for more style updates.