### PR TITLE
removes the accordion and sticky semantic-ui elements

### DIFF
--- a/app/assets/javascripts/common.js
+++ b/app/assets/javascripts/common.js
@@ -4,37 +4,8 @@ document.addEventListener("turbolinks:load", () => {
     $(event.target).closest(".message").transition("fade")
   })
 
-  $(".ui.accordion").accordion()
-
   // Toggle the sidebar open and closed
   $(".sidebar.icon").parent().on("click", () => $(".ui.sidebar").sidebar("toggle"))
-
-  // Handle making the side menus sticky
-  $("[data-behavior~=sticky]").each((idx, element) => {
-    if($(element.dataset.context).length < 1)
-      return
-
-    // Hack to get around sticky setting the menu to height: 100% causing there
-    // to be a big gap between the menu and content to scroll through
-    const style = window.getComputedStyle(element)
-    if(style.display === "none") {
-      [
-        "mobile",
-        "hidden"
-      ].forEach(c => element.classList.remove(c))
-
-      element.dataset.behavior = "non-sticky"
-
-      return
-    }
-
-    let stickySettings = Object.assign({ }, element.dataset)
-
-    if(stickySettings.offset)
-      stickySettings.offset = parseInt(stickySettings.offset)
-
-    $(element).sticky(stickySettings)
-  })
 
   tagDropdown(
     "[data-behavior~=autocomplete-image-tags]",

--- a/app/assets/javascripts/common/bulk-actions.js
+++ b/app/assets/javascripts/common/bulk-actions.js
@@ -19,28 +19,6 @@ class BulkActions {
   toggleBulkActionsVisibility(shouldShow) {
     this._actions.toggleClass("hidden", !shouldShow)
     this._menus.toggleClass("hidden", !shouldShow)
-
-    const sticky = this._actions.parents("[data-behavior~=sticky]")
-    if(sticky.length < 1) return
-
-    // Hack to get around sticky setting the menu to height: 100% causing there
-    // to be a big gap between the menu and content to scroll through
-    const element = sticky.get(0)
-    const style = window.getComputedStyle(element)
-    if(style.display === "none") {
-      [
-        "mobile",
-        "hidden"
-      ].forEach(c => element.classList.remove(c))
-
-      element.dataset.behavior = "non-sticky"
-
-      return
-    }
-
-    console.log(sticky)
-
-    sticky.sticky("refresh")
   }
 
   toggleSelectAllChecked(shouldShow) {

--- a/app/views/admin/bookmarks/show.html.haml
+++ b/app/views/admin/bookmarks/show.html.haml
@@ -99,22 +99,12 @@
                   .date= offline_cache.created_at.to_s(:long)
 
                 .extra.text
-                  .ui.accordion
-                    .title
-                      %i.dropdown.icon
-                      - asset_count = offline_cache.assets.count
-                      = asset_count
-                      = "Asset".pluralize asset_count
-                      = error_count_label offline_cache.error_messages
+                  .title
+                    - asset_count = offline_cache.assets.count
+                    = asset_count
+                    = "Asset".pluralize asset_count
+                    = error_count_label offline_cache.error_messages
 
-                    .content
-                      .ui.list
-                        - offline_cache.assets.each do |asset|
-                          .item
-                            %i.file.icon
-                            .content
-                              .header= asset.blob.metadata.dig("uri")
-                              .description= asset.blob.content_type
 - else
   %h2.ui.dividing.header Cache History
   %p None :(


### PR DESCRIPTION
Sticky has been buggy and the accordion just isn't really needed. I need to rethink the error/cache history timeline in the admin view anyways so I'll address it later.