### PR TITLE
Turbolinks CSP Nonce sadness

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -20,7 +20,7 @@ module ApplicationHelper
 
     records.each_with_object({}) do |record, memo|
       memo[ record.id ] = attributes.each_with_object({}) do |attribute, record_memo|
-        record_memo[ attribute ] = record.send(attribute).to_s
+        record_memo[ attribute ] = record.send(attribute).as_json
       end
     end
   end

--- a/app/javascript/packs/admin.js
+++ b/app/javascript/packs/admin.js
@@ -17,6 +17,17 @@ import "channels"
 
 import "../styles/admin"
 
+/** Turbolinks and inline body script tags with a CSP nonce don't seem to play nice.
+ * Probably not recommended to do this but :/ Nothing else it working
+ *
+ * this is a vanilla version of whats documented here
+ * https://github.com/turbolinks/turbolinks/issues/430
+ */
+document.addEventListener("turbolinks:request-start", event => {
+  const xhr = event.data.xhr
+  xhr.setRequestHeader("X-Turbolinks-Nonce", Rails.cspNonce())
+})
+
 Rails.start()
 Turbolinks.start()
 ActiveStorage.start()

--- a/app/views/admin/bookmarks/index.html.haml
+++ b/app/views/admin/bookmarks/index.html.haml
@@ -2,7 +2,7 @@
   Bookmarks
 
 - content_for :store do
-  != { records: store_records(@bookmarks, only: [:id, :uri, :user]) }.to_json
+  != { records: store_records(@bookmarks, only: [:id, :title, :uri]) }.to_json
 
 - content_for :menu do
   .bulk-action-menu

--- a/app/views/layouts/admin/_body.html.haml
+++ b/app/views/layouts/admin/_body.html.haml
@@ -2,7 +2,6 @@
   window.__initStore__ = {}
   - if content_for? :store
     window.__initStore__ = #{ raw content_for(:store) }
-  console.log("hi")
 
 = render partial: "layouts/admin/sidebar"
 

--- a/app/views/layouts/admin/_head.html.haml
+++ b/app/views/layouts/admin/_head.html.haml
@@ -1,5 +1,6 @@
 %meta{ :content => "width=device-width, initial-scale=1, shrink-to-fit=no", "name" => "viewport" }
 %meta{ :content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type" }
+%meta{ :name => "turbolinks-cache-control", :content => "no-cache" }
 
 = content_for :meta
 

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -36,8 +36,13 @@ Rails.application.config.content_security_policy do |policy|
 end
 
 # If you are using UJS then enable automatic nonce generation
-Rails.application.config.content_security_policy_nonce_generator = -> request { SecureRandom.base64(16) }
-
+Rails.application.config.content_security_policy_nonce_generator = -> request do
+  if request.env['HTTP_TURBOLINKS_REFERRER'].present?
+    request.env['HTTP_X_TURBOLINKS_NONCE']
+  else
+    SecureRandom.base64(16)
+  end
+end
 # Set the nonce only to specific directives
 # Rails.application.config.content_security_policy_nonce_directives = %w(script-src)
 

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -19,11 +19,11 @@
 
 Rails.application.config.content_security_policy do |policy|
   policy.default_src :self, :https
-  policy.font_src    :self, :https, :data, "fonts.gstatic.com"
+  policy.font_src    :self, :https, :data
   policy.img_src     :self, :https, :data
   policy.object_src  :none
   policy.script_src  :self, :https
-  policy.style_src   :self, :https, "fonts.googleapis.com"
+  policy.style_src   :self, :https
 
   if Rails.env.development?
     policy.default_src :self, :https, "http://localhost:*", "ws://localhost:*", "http://localhost:8080"


### PR DESCRIPTION
Turbolinks seems to have some problems with running inline scripts when CSP Nonces are set and the inline script has a different CSP Nonce than what Turbolinks was loaded with.

From https://github.com/turbolinks/turbolinks/issues/430 I've vanilla-fied the working solution, which is to set the same Nonce for each page request Turbolinks makes. This doesn't seem super ideal as Nonce's aren't supposed to be reused. Additionally, with the Turbolinks cache disabled (it's been disabled before, I re-enabled it in #122 to try), there isn't nearly as much of a benefit from using Turbolinks, so it might just be time to ditch it until I or the Turbolinks project figures out a better way to handle inline Nonce scripts?