### PR TITLE
Styles updates

### DIFF
--- a/app/controllers/bookmarks/tag_wizard_controller.rb
+++ b/app/controllers/bookmarks/tag_wizard_controller.rb
@@ -1,6 +1,4 @@
 class Bookmarks::TagWizardController < ApplicationController
-  layout "page"
-
   require_login!
   before_action :set_bookmark, only: [:update]
 
@@ -29,15 +27,15 @@ class Bookmarks::TagWizardController < ApplicationController
     if bookmark_params[:tags].any? && @bookmark.update(bookmark_params)
       redirect_to bookmarks_tag_wizard_index_path, notice: "Bookmark tagged!"
     else
-      flash.notice = "You've got to add at least one tag to the bookmark, silly"
-      render :index
+      flash.alert = "You've got to add at least one tag to the bookmark!"
+      redirect_to bookmarks_tag_wizard_index_path
     end
   end
 
   private
 
   def set_bookmark
-    @bookmark = Bookmark.find params[:id]
+    @bookmark = current_user.bookmarks.find params[:id]
 
     authorize @bookmark
   end

--- a/app/javascript/styles/admin.css
+++ b/app/javascript/styles/admin.css
@@ -1,12 +1,28 @@
 @import "components/_buttons";
-@import "components/_modal";
 @import "components/_checkbox";
-@import "components/_bulk_action_menu";
-@import "components/_backgrounds";
 @import "components/_tables";
+@import "components/_time";
+
+@import "components/_tags";
+
+@import "components/_backgrounds";
+@import "components/_modal";
+
+@import "components/_pager";
+@import "components/_bulk_action_menu";
+@import "components/_service_announcement";
+@import "components/_bookmark_card";
 
 @tailwind base;
 @tailwind components;
+
+.tb.service-announcement {
+  @apply rounded-none border-r-0 border-t-0 border-l-0;
+
+  .announcement-icon {
+    @apply rounded-none;
+  }
+}
 
 @tailwind utilities;
 

--- a/app/javascript/styles/components/_bookmark_card.css
+++ b/app/javascript/styles/components/_bookmark_card.css
@@ -1,0 +1,23 @@
+.tb.bookmark-card {
+  @apply w-full flex mb-2;
+
+  & .card-menu {
+    @apply h-12 h-auto bg-cover rounded-l bg-gray-200 p-4 flex flex-col justify-between;
+  }
+
+  & .card-body {
+    @apply border-r border-b border-t border-gray-200 rounded-r p-4 flex flex-col justify-between leading-normal w-full;
+
+    & h4 {
+      @apply text-black font-bold text-xl mb-2;
+
+      & small {
+        @apply font-thin text-sm text-gray-500;
+      }
+    }
+
+    & .tb.footer {
+      @apply flex flex-col mt-2;
+    }
+  }
+}

--- a/app/javascript/styles/components/_pager.css
+++ b/app/javascript/styles/components/_pager.css
@@ -1,0 +1,34 @@
+nav.tb.pager {
+  @apply mb-4 flex flex-row flex-grow border border-gray-300 rounded w-full;
+
+  @screen md {
+    width: max-content;
+  }
+
+  & .item {
+    @apply flex-grow py-3 px-4 text-gray-800 font-semibold text-base border border-l-0 border-t-0 border-b-0 border-gray-300 text-center;
+
+    @screen md {
+      flex-grow: 0;
+    }
+
+    &:first-child {
+      @apply border-l-0 ml-0;
+    }
+
+    &:last-child {
+      @apply border-r-0 mr-0;
+    }
+
+    &:not(:first-child):not(:last-child) {
+    }
+
+    &:hover {
+      @apply bg-gray-200;
+    }
+
+    &.active {
+      @apply bg-gray-300;
+    }
+  }
+}

--- a/app/javascript/styles/components/_service_announcement.css
+++ b/app/javascript/styles/components/_service_announcement.css
@@ -51,6 +51,14 @@
     .announcement-body-message {
       @apply text-gray-700 font-medium text-sm text-center px-2 pt-1;
 
+      & a {
+        @apply text-blue-500;
+
+        &:hover {
+          @apply text-blue-700;
+        }
+      }
+
       @screen md {
         @apply text-left;
       }

--- a/app/javascript/styles/components/_service_announcement.css
+++ b/app/javascript/styles/components/_service_announcement.css
@@ -4,6 +4,30 @@
   .announcement-icon {
     @apply flex justify-center items-center text-white font-bold text-6xl rounded-l rounded-r-none;
 
+    &.service-announcement-bg-plain {
+      @apply bg-gray-400;
+    }
+
+    &.service-announcement-bg-olive {
+      background-color: #b5cc18;
+    }
+
+    &.service-announcement-bg-violet {
+      background-color: #6435c9;
+    }
+
+    &.service-announcement-bg-brown {
+      background-color: #a5673f;
+    }
+
+    &.service-announcement-bg-grey {
+      @apply bg-gray-800;
+    }
+
+    &.service-announcement-bg-black {
+      background-color: #000;
+    }
+
     @screen md {
       @apply w-32;
     }

--- a/app/javascript/styles/components/_service_announcement.css
+++ b/app/javascript/styles/components/_service_announcement.css
@@ -1,0 +1,35 @@
+.tb.service-announcement {
+  @apply flex border border-gray-300 mb-4 rounded;
+
+  .announcement-icon {
+    @apply flex justify-center items-center text-white font-bold text-6xl rounded-l rounded-r-none;
+
+    @screen md {
+      @apply w-32;
+    }
+
+    & > i.icon {
+      height: initial;
+    }
+  }
+
+  .announcement-body {
+    @apply w-full bg-white px-2 py-5 tracking-wide;
+
+    .announcement-body-title {
+      @apply font-semibold text-gray-900 text-xl text-center px-2;
+
+      @screen md {
+        @apply text-left;
+      }
+    }
+
+    .announcement-body-message {
+      @apply text-gray-700 font-medium text-sm text-center px-2 pt-1;
+
+      @screen md {
+        @apply text-left;
+      }
+    }
+  }
+}

--- a/app/javascript/styles/components/_tags.css
+++ b/app/javascript/styles/components/_tags.css
@@ -1,0 +1,7 @@
+.tb.tags {
+  @apply flex flex-row flex-wrap mt-1;
+}
+
+.tb.tag {
+  @apply inline-block bg-gray-200 rounded px-3 py-1 text-sm font-semibold text-gray-700 mr-2 mb-1;
+}

--- a/app/javascript/styles/components/_time.css
+++ b/app/javascript/styles/components/_time.css
@@ -1,0 +1,3 @@
+time {
+  @apply text-sm text-gray-500;
+}

--- a/app/javascript/styles/components/_typography.css
+++ b/app/javascript/styles/components/_typography.css
@@ -1,0 +1,39 @@
+.tb {
+  & h1,
+  & h2,
+  & h3,
+  & h4,
+  & h5,
+  & h6 {
+    @apply font-bold text-gray-900;
+
+    &.dividing {
+      @apply pb-2 border-b border-gray-200;
+    }
+  }
+
+  & h1 {
+    @apply text-4xl mb-4;
+  }
+
+  & h2 {
+    @apply text-3xl mb-4;
+  }
+
+  & h3 {
+    @apply text-2xl mb-3;
+  }
+
+  & h4 {
+    @apply text-xl mb-2;
+  }
+
+  & h5,
+  & h6 {
+    @apply text-lg mb-2;
+  }
+
+  & p {
+    @apply text-gray-800 text-base;
+  }
+}

--- a/app/javascript/styles/public.css
+++ b/app/javascript/styles/public.css
@@ -1,25 +1,24 @@
+@import "components/_typography";
 @import "components/_buttons";
-@import "components/_modal";
 @import "components/_checkbox";
-@import "components/_bulk_action_menu";
-@import "components/_backgrounds";
 @import "components/_tables";
+@import "components/_time";
+
+@import "components/_tags";
+
+@import "components/_backgrounds";
+@import "components/_modal";
+
+@import "components/_pager";
+@import "components/_bulk_action_menu";
+@import "components/_service_announcement";
+@import "components/_bookmark_card";
 
 @tailwind base;
 @tailwind components;
 
-.ui.top.fixed.menu {
-  max-height: 52px;
-}
-
-.tb nav.pagination.menu {
-  @apply mb-4 flex flex-col;
-
-  width: max-content;
-
-  @screen md {
-    @apply flex-row;
-  }
+nav.navbar {
+  max-height: var(--navbar-height) !important;
 }
 
 .main:not(.old):not(.pages) {
@@ -34,75 +33,44 @@
   @apply mt-0;
 }
 
+.tb {
+  --sidebar-width: 24rem;
+  --navbar-height: 52px;
+}
+
 aside.tb.sidebar-menu {
-  @apply w-full p-4 text-white flex-shrink-0 block border-t border-b;
+  @apply w-full p-4 flex-shrink-0 block border-t border-b text-white;
 
   background-color: #1b1c1d;
 
   border-color: rgba(224, 224, 224, 0.2);
 
   @screen lg {
-    @apply w-1/4 inset-y-0 left-0 max-w-sm;
+    @apply fixed inset-y-0 left-0;
+
+    width: var(--sidebar-width);
+    top: var(--navbar-height);
   }
 
-  & &.bulk-action-menu {
-    @apply flex flex-col;
+  h2 {
+    @apply text-white;
   }
 }
 
 main.tb {
-  @apply p-4 mt-0 flex flex-col w-full;
+  @apply p-4 mt-0 flex flex-col;
 
   /*
    * Takes care of semantic UI adding a margin to the top of the last child in
    * the ".pusher.main"
    * */
   margin-top: 0px !important;
-}
 
-.tb.bookmark-card {
-  @apply w-full flex mb-2;
+  @screen lg {
+    @apply relative;
 
-  & .card-menu {
-    @apply h-12 h-auto bg-cover rounded-l bg-gray-200 p-4 flex flex-col justify-between;
-  }
-
-  & .card-body {
-    @apply border-r border-b border-t border-gray-200 rounded-r p-4 flex flex-col justify-between leading-normal w-full;
-
-    & h4 {
-      @apply text-black font-bold text-xl mb-2;
-
-      & small {
-        @apply font-thin text-sm text-gray-500;
-      }
-    }
-
-    & .tb.footer {
-      @apply flex flex-col mt-2;
-    }
-  }
-}
-
-.tb {
-  & p {
-    @apply text-gray-700 text-base;
-  }
-
-  & time {
-    @apply text-sm text-gray-500;
-  }
-
-  & .messages {
-    @apply mb-2;
-  }
-}
-
-.tb.tags {
-  @apply flex flex-row flex-wrap mt-1;
-
-  .tb.tag {
-    @apply inline-block bg-gray-200 rounded px-3 py-1 text-sm font-semibold text-gray-700 mr-2 mb-1;
+    left: var(--sidebar-width);
+    width: calc(100% - var(--sidebar-width));
   }
 }
 

--- a/app/javascript/styles/public.css
+++ b/app/javascript/styles/public.css
@@ -36,6 +36,10 @@ nav.navbar {
 .tb {
   --sidebar-width: 24rem;
   --navbar-height: 52px;
+
+  & hr {
+    @apply border-b border-gray-200 my-4;
+  }
 }
 
 aside.tb.sidebar-menu {

--- a/app/javascript/styles/public.css
+++ b/app/javascript/styles/public.css
@@ -29,6 +29,16 @@ nav.navbar {
   }
 }
 
+body.pages {
+  .tb.service-announcement {
+    @apply rounded-none border-r-0 border-t-0 border-l-0;
+
+    .announcement-icon {
+      @apply rounded-none;
+    }
+  }
+}
+
 .ui.footer.segment {
   @apply mt-0;
 }

--- a/app/views/admin/service_announcements/show.html.haml
+++ b/app/views/admin/service_announcements/show.html.haml
@@ -79,4 +79,4 @@
 
 %h2.ui.dividing.header Preview
 
-= render partial: "layouts/service_announcements", locals: { service_announcements: [ @service_announcement ] }
+= render partial: "layouts/common/service_announcements", locals: { service_announcements: [ @service_announcement ] }

--- a/app/views/bookmarks/edit.html.haml
+++ b/app/views/bookmarks/edit.html.haml
@@ -7,6 +7,6 @@
       %i.chevron.left.icon
       Back to bookmark
 
-%h2.ui.dividing.header Editing Bookmark
+%h2.dividing Editing Bookmark
 
 = render partial: "form", locals: { bookmark: @bookmark }

--- a/app/views/bookmarks/index.html.haml
+++ b/app/views/bookmarks/index.html.haml
@@ -1,7 +1,7 @@
 - content_for :page_title do
   Bookmarks
 
-%h2.ui.dividing.header Your bookmarks
+%h2.dividing Your bookmarks
 
 - store_content records: store_records(@bookmarks, only: [:id, :title, :uri])
 

--- a/app/views/bookmarks/new.html.haml
+++ b/app/views/bookmarks/new.html.haml
@@ -7,6 +7,6 @@
       %i.chevron.left.icon
       Back to bookmarks
 
-%h2.ui.dividing.header New Bookmark
+%h2.dividing New Bookmark
 
 = render partial: "form", locals: { bookmark: @bookmark }

--- a/app/views/bookmarks/search/index.html.haml
+++ b/app/views/bookmarks/search/index.html.haml
@@ -9,7 +9,16 @@
       = search_field_tag "q", params[:q], class: "ui prompt", placeholder: "Search Bookmarks ...", aria: { label: "search" }
     %i.search.icon
 
-%h1 Search Results
+- content_for :sidebar do
+  - if @bookmarks.any?
+    .tb.bulk-action-menu
+      = react_component "BulkActions/SelectAll", label: "Select All Bookmarks"
+
+      = react_component "BulkActions/Header"
+      = react_component "BulkActions/public/TagAll", actionUrl: bookmarks_bulk_tag_path, autocompleteUrl: bookmarks_autocomplete_index_path
+      = react_component "BulkActions/public/DeleteAll", actionUrl: bookmarks_bulk_delete_path
+
+%h1.dividing Search Results
 - if @error
   = render partial: "query_error"
 - elsif params[:q].blank?

--- a/app/views/bookmarks/show.html.haml
+++ b/app/views/bookmarks/show.html.haml
@@ -35,7 +35,7 @@
 = model_tag @bookmark, only: [ :uri, :title ], no_checkbox: true
 
 .flex.flex-col.justify-between{ class: "lg:flex-row" }
-  .column.w-full
+  .column.w-full{ class: "lg:mr-2 sm:mb-2" }
     %h2.font-bold.text-3xl= @bookmark.title
 
     = link_to @bookmark.uri.to_s, @bookmark.uri.to_s

--- a/app/views/bookmarks/show.html.haml
+++ b/app/views/bookmarks/show.html.haml
@@ -17,14 +17,14 @@
     %h2 Offline Archive
 
     - if @bookmark.current_offline_cache.present?
-      Archive made on
-      %time{ datetime: @bookmark.current_offline_cache.created_at.rfc2822 }
-        = @bookmark.current_offline_cache.created_at.to_s(:long)
-        UTC
+      .archive-info
+        Archive made
+        = render "components/time", time: @bookmark.current_offline_cache.created_at
 
       = link_to "View Archive", bookmark_cache_index_path(@bookmark), data: { turbolinks: false }, class: "button button-white-outline hover:button-white text-white hover:text-gray-800"
     - else
-      No archive available
+      .archive-info
+        No archive available
 
     = button_to bookmark_cache_index_path(@bookmark), class: "button button-white-outline hover:button-white text-white hover:text-gray-800" do
       - if @bookmark.offline_caches.any?
@@ -34,23 +34,20 @@
 
 = model_tag @bookmark, only: [ :uri, :title ], no_checkbox: true
 
-.ui.fluid.horizontally.padded.stackable.grid
-  .eight.wide.column
-    %h2.ui.header
-      .content= @bookmark.title
+.flex.flex-col.justify-between{ class: "lg:flex-row" }
+  .column.w-full
+    %h2.font-bold.text-3xl= @bookmark.title
 
     = link_to @bookmark.uri.to_s, @bookmark.uri.to_s
-    %time{ datetime: @bookmark.created_at.rfc2822 }
-      = @bookmark.created_at.to_s(:long)
-      UTC
+    = render "components/time", time: @bookmark.created_at
 
-    .ui.item
-      .ui.small.labels
-        - @bookmark.tags.each do |tag|
-          = link_to bookmarks_tag_path(tag) do
-            .ui.label{ class: [tag.color] }= tag.label
+    = render "components/tags", tags: @bookmark.tags do |tag|
+      = bookmarks_tag_path(tag)
 
-  .eight.wide.column
+  .column.w-full
     - if @bookmark.description.present?
       :markdown
         #{ @bookmark.description }
+
+    - else
+      %em No description ...

--- a/app/views/bookmarks/tag_wizard/_form.html.haml
+++ b/app/views/bookmarks/tag_wizard/_form.html.haml
@@ -1,4 +1,4 @@
-= form_with model: bookmark, url: bookmarks_tag_wizard_path(bookmark), class: "ui fluid form", html: { autocomplete: "off" } do |f|
+= form_with model: bookmark, url: bookmarks_tag_wizard_path(bookmark), local: true, class: "ui fluid form", html: { autocomplete: "off" } do |f|
   - if bookmark.errors.any?
     .ui.message.error
       %h2= "#{ pluralize bookmark.errors.count, "error" } prohibited this bookmark from being saved:"

--- a/app/views/bookmarks/tag_wizard/index.html.haml
+++ b/app/views/bookmarks/tag_wizard/index.html.haml
@@ -1,34 +1,51 @@
 - content_for :page_title do
   Bookmark '#{ @bookmark.title }'
 
-- content_for :secondary_navbar do
-  - if @bookmark.offline_caches.any?
-    = link_to "offline cache", bookmark_cache_index_path(@bookmark), data: { turbolinks: false }, class: "ui item"
+- content_for :sidebar do
+  .tb.bulk-action-menu
+    %h2 Actions
+    = link_to bookmark_path(@bookmark), class: "button button-white-outline hover:button-white text-white hover:text-gray-800" do
+      %i.linkify.icon
+      View
 
-  = link_to "edit", edit_bookmark_path(@bookmark), class: "ui item"
+    = link_to edit_bookmark_path(@bookmark), class: "button button-white-outline hover:button-white text-white hover:text-gray-800" do
+      %i.pencil.icon
+      Edit
 
-  .right.menu
-    = modal_tag @bookmark, :delete, url: bookmark_path(@bookmark) do
-      delete
+    -# TODO: replace
+    = modal_tag @bookmark, :delete, url: bookmark_path(@bookmark), class: "button button-red-outline hover:button-red" do
+      %i.trash.can.icon
+      Delete
 
-.ui.raised.very.padded.text.container.segment
-  %h1 Tag Wizard!
-  %p
-    The tag wizard makes it easy for you to work through your backlog of untagged bookmarks!
+    %h2 Offline Archive
 
-  %h3= @bookmark.title
+    - if @bookmark.current_offline_cache.present?
+      .archive-info
+        Archive made
+        = render "components/time", time: @bookmark.current_offline_cache.created_at
+
+      = link_to "View Archive", bookmark_cache_index_path(@bookmark), data: { turbolinks: false }, class: "button button-white-outline hover:button-white text-white hover:text-gray-800"
+    - else
+      .archive-info
+        No archive available
+
+%h1 Tag Wizard!
+%p
+  The tag wizard makes it easy for you to work through your backlog of untagged bookmarks!
+
+%hr
+
+%div{ class: "w-full lg:w-1/3" }
+  %h2.font-bold.text-3xl= @bookmark.title
 
   = link_to @bookmark.uri.to_s, @bookmark.uri.to_s
   = render "components/time", time: @bookmark.created_at
 
-  %hr
-
   = render partial: 'form', locals: { bookmark: @bookmark }
 
   - if @bookmark.description.present?
-    %h3 Need a little more info?
+    :markdown
+      #{ @bookmark.description }
 
-    %p
-      %strong Description:
-      :markdown
-        #{ @bookmark.description }
+  - else
+    %em No description ...

--- a/app/views/bookmarks/tag_wizard/index.html.haml
+++ b/app/views/bookmarks/tag_wizard/index.html.haml
@@ -12,24 +12,23 @@
       delete
 
 .ui.raised.very.padded.text.container.segment
-  %h1.ui.header Tag Wizard!
+  %h1 Tag Wizard!
   %p
     The tag wizard makes it easy for you to work through your backlog of untagged bookmarks!
 
-  %h3.ui.header= @bookmark.title
+  %h3= @bookmark.title
 
   = link_to @bookmark.uri.to_s, @bookmark.uri.to_s
-  .date
-    = @bookmark.created_at.to_s(:long)
-    UTC
+  = render "components/time", time: @bookmark.created_at
 
   %hr
 
   = render partial: 'form', locals: { bookmark: @bookmark }
 
   - if @bookmark.description.present?
-    %h3.ui.header Need a little more info?
+    %h3 Need a little more info?
 
     %p
       %strong Description:
-      = simple_format @bookmark.description
+      :markdown
+        #{ @bookmark.description }

--- a/app/views/bookmarks/tags/show.html.haml
+++ b/app/views/bookmarks/tags/show.html.haml
@@ -13,9 +13,9 @@
       = react_component "BulkActions/public/DeleteAll", actionUrl: bookmarks_bulk_delete_path
 
 - if @bookmarks.any?
-  %h2.ui.dividing.header
+  %h2.dividing
     Tag:
-    .ui.massive.label{ class: [ @tag.color ] }= @tag.label
+    %span.tb.tag{ class: "bg-#{ @tag.color }-500" }= @tag.label
 
   = paginate @bookmarks
 

--- a/app/views/components/_bookmark_card.html.haml
+++ b/app/views/components/_bookmark_card.html.haml
@@ -1,4 +1,3 @@
-
 .tb.bookmark-card
   .tb.card-menu
     = yield
@@ -17,7 +16,7 @@
       - unless bookmark.description.blank?
         = bookmark.description.truncate(80)
       - else
-        %em No description
+        %em No description ...
 
     .tb.card-footer
       = render "components/time", time: bookmark.created_at

--- a/app/views/components/_tags.html.haml
+++ b/app/views/components/_tags.html.haml
@@ -1,7 +1,7 @@
 .tb.tags
   - tags.each do |tag|
     = link_to yield(tag) do
-      %span{ class: ["tb tag bg-#{tag.color}-500"] }= tag.label
+      %span.tb.tag{ class: "bg-#{ tag.color }-500" }= tag.label
 
   -#%button.tb.tag
     %i.plus.icon

--- a/app/views/components/_time.html.haml
+++ b/app/views/components/_time.html.haml
@@ -1,3 +1,3 @@
-%time{ datetime: time, title: time.to_s(:long_ordinal) }
+%time{ datetime: time.rfc2822, title: time.to_s(:long_ordinal) }
   = distance_of_time_in_words_to_now(time)
   ago

--- a/app/views/kaminari/_paginator.html.haml
+++ b/app/views/kaminari/_paginator.html.haml
@@ -1,11 +1,13 @@
 = paginator.render do
-  %nav.ui.pagination.stackable.menu
+  %nav.tb.pager
     = first_page_tag unless current_page.first?
     = prev_page_tag unless current_page.first?
+
     - each_page do |page|
       - if page.left_outer? || page.right_outer? || page.inside_window?
         = page_tag page
       - elsif !page.was_truncated?
         = gap_tag
+
     = next_page_tag unless current_page.last?
     = last_page_tag unless current_page.last?

--- a/app/views/layouts/admin/_body.html.haml
+++ b/app/views/layouts/admin/_body.html.haml
@@ -2,9 +2,8 @@
 = render "layouts/admin/mobile_nav"
 
 .ui.pusher.main
-  .messages
-    = render_service_announcements
-    = semantic_flash
+  = render_service_announcements
+  = semantic_flash
 
   .ui.fluid.stackable.container
     - if partial_for? "menu"

--- a/app/views/layouts/application/_body.html.haml
+++ b/app/views/layouts/application/_body.html.haml
@@ -6,9 +6,8 @@
     = content_for :sidebar
 
   %main.tb
-    .messages
-      = render_service_announcements
-      = semantic_flash
+    = render_service_announcements
+    = semantic_flash
 
     = yield
 

--- a/app/views/layouts/common/_mobile_nav.html.haml
+++ b/app/views/layouts/common/_mobile_nav.html.haml
@@ -1,5 +1,5 @@
 // Mobile nav
-.ui.top.fixed.inverted.menu.mobile.only
+%nav.tb.navbar.ui.top.fixed.inverted.menu.mobile.only
   .clickable.item
     %i.large.sidebar.icon
 

--- a/app/views/layouts/common/_navbar.html.haml
+++ b/app/views/layouts/common/_navbar.html.haml
@@ -2,7 +2,7 @@
   = render partial: "navbar"
 
 // Desktop nav
-.ui.top.fixed.inverted.menu.responsive.mobile.hidden
+%nav.tb.navbar.ui.top.fixed.inverted.menu.responsive.mobile.hidden
   = link_to root_path, class: "header item" do
     = image_tag "bug_logo.png", class: "logo"
     transientBug

--- a/app/views/layouts/common/_service_announcements.html.haml
+++ b/app/views/layouts/common/_service_announcements.html.haml
@@ -22,7 +22,7 @@
             #{ service_announcement.message }
 
     .tb.service-announcement
-      .announcement-icon{ class: "bg-#{ service_announcement.color }-800" }
+      .announcement-icon{ class: "bg-#{ service_announcement.color }-800 service-announcement-bg-#{ service_announcement.color }" }
         %i.icon{ class: [ service_announcement.icon ] }
 
       .announcement-body

--- a/app/views/layouts/common/_service_announcements.html.haml
+++ b/app/views/layouts/common/_service_announcements.html.haml
@@ -1,12 +1,32 @@
 - if service_announcements&.any?
   - service_announcements.each do |service_announcement|
-    .ui.message{ class: [ service_announcement.color, (service_announcement.icon ? "icon" : "")] }
-      - if service_announcement.icon
+    -#.inline-flex.items-center.bg-white.leading-none.rounded-full.p-2.shadow.text-sm.w-full{ class: [ "text-#{ service_announcement.color }-800" ] }
+      -#%span.inline-flex.text-white.rounded-full.h-6.px-3.justify-center.items-center{ class: [ "bg-#{ service_announcement.color }-800" ] }
+        -#- if service_announcement.icon
+          -#%i.icon{ class: [ service_announcement.icon ] }
+
+        -#= service_announcement.title
+
+      -#%p.inline-flex.px-2
+        -#:markdown
+          -##{ service_announcement.message }
+
+    -#.flex.border.border-gray-400
+      .flex.justify-center.items-center.text-white.font-bold.text-6xl{ class: "w-2/12 bg-#{ service_announcement.color }-700" }
         %i.icon{ class: [ service_announcement.icon ] }
 
-      .content
-        .header
-          = service_announcement.title
-        %p
+      .w-full.px-1.bg-white.py-5.tracking-wide{ class: "lg:w-10/12" }
+        .font-semibold.text-gray-900.text-xl.text-center.px-2{ class: "lg:text-left" }= service_announcement.title
+        .text-gray-700.font-medium.text-sm.pt-1.text-center.px-2{ class: "lg:text-left" }
+          :markdown
+            #{ service_announcement.message }
+
+    .tb.service-announcement
+      .announcement-icon{ class: "bg-#{ service_announcement.color }-800" }
+        %i.icon{ class: [ service_announcement.icon ] }
+
+      .announcement-body
+        .announcement-body-title= service_announcement.title
+        .announcement-body-message
           :markdown
             #{ service_announcement.message }


### PR DESCRIPTION
More work on getting rid of semantic-ui styling, this overhauls the pagination and service announcement elements along with tweaking and adjusting styling for most of the bookmarks side of things. It also converts the tag wizard to the newer sidebar view.

The sidebar view now has it's sidebar fixed, which helps with bulk selects by keeping the actions always visible as you scroll. It also fixes some styling issues with the pagination when viewing it in mobile.

![image](https://user-images.githubusercontent.com/94542/71492906-0fe10800-27f8-11ea-93c6-17f432b6f60e.png)

![image](https://user-images.githubusercontent.com/94542/71492913-212a1480-27f8-11ea-8dec-171906fd6399.png)
