### PR TITLE
basic rack-attack config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,8 +28,9 @@ gem "connection_pool"
 gem "redis-rails"
 gem "redis-rack-cache"
 
-# CORS
+# CORS & other Security
 gem "rack-cors"
+gem "rack-attack"
 
 # Needed for has_secure_password
 gem "bcrypt"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -298,6 +298,8 @@ GEM
     puma (4.3.1)
       nio4r (~> 2.0)
     rack (2.0.8)
+    rack-attack (6.2.2)
+      rack (>= 1.0, < 3)
     rack-cache (1.9.0)
       rack (>= 0.4)
     rack-cors (1.0.5)
@@ -541,6 +543,7 @@ DEPENDENCIES
   pry-rails
   puma
   pundit!
+  rack-attack
   rack-cors
   rack-test
   rails (~> 6.0.0)

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,4 +1,4 @@
-Rack::Attack.enabled = false if Rails.env.development?
+Rack::Attack.enabled = false if Rails.env.development? || Rails.env.test?
 
 class Rack::Attack
 

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,79 @@
+Rack::Attack.enabled = false if Rails.env.development?
+
+class Rack::Attack
+
+  ### Configure Cache ###
+
+  # If you don't want to use Rails.cache (Rack::Attack's default), then
+  # configure it here.
+  #
+  # Note: The store is only used for throttling (not blocklisting and
+  # safelisting). It must implement .increment and .write like
+  # ActiveSupport::Cache::Store
+
+  # Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+
+  ### Throttle Spammy Clients ###
+
+  # If any single client IP is making tons of requests, then they're
+  # probably malicious or a poorly-configured scraper. Either way, they
+  # don't deserve to hog all of the app server's CPU. Cut them off!
+  #
+  # Note: If you're serving assets through rack, those requests may be
+  # counted by rack-attack and this throttle may be activated too
+  # quickly. If so, enable the condition to exclude them from tracking.
+
+  # Throttle all requests by IP (60rpm)
+  #
+  # Key: "rack::attack:#{Time.now.to_i/:period}:req/ip:#{req.ip}"
+  throttle("req/ip", limit: 300, period: 5.minutes) do |req|
+    req.ip unless req.path.start_with?("/csp-violation-report") && req.post?
+  end
+
+  ### Prevent Brute-Force Login Attacks ###
+
+  # The most common brute-force login attack is a brute-force password
+  # attack where an attacker simply tries a large number of emails and
+  # passwords to see if any credentials match.
+  #
+  # Another common method of attack is to use a swarm of computers with
+  # different IPs to try brute-forcing a password for a specific account.
+
+  # Throttle POST requests to /login by IP address
+  #
+  # Key: "rack::attack:#{Time.now.to_i/:period}:logins/ip:#{req.ip}"
+  throttle("logins/ip", limit: 5, period: 20.seconds) do |req|
+    if req.path == "/login" && req.post?
+      req.ip
+    end
+  end
+
+  # Throttle POST requests to /login by email param
+  #
+  # Key: "rack::attack:#{Time.now.to_i/:period}:logins/email:#{req.email}"
+  #
+  # Note: This creates a problem where a malicious user could intentionally
+  # throttle logins for another user and force their login requests to be
+  # denied, but that's not very common and shouldn't happen to you. (Knock
+  # on wood!)
+  throttle("logins/email", limit: 5, period: 20.seconds) do |req|
+    if req.path == "/login" && req.post?
+      # return the email if present, nil otherwise
+      req.params["email"].presence
+    end
+  end
+
+  ### Custom Throttle Response ###
+
+  # By default, Rack::Attack returns an HTTP 429 for throttled responses,
+  # which is just fine.
+  #
+  # If you want to return 503 so that the attacker might be fooled into
+  # believing that they've successfully broken your app (or you just want to
+  # customize the response), then uncomment these lines.
+  # self.throttled_response = lambda do |env|
+  #  [ 503,  # status
+  #    {},   # headers
+  #    ['']] # body
+  # end
+end


### PR DESCRIPTION
Been getting a bunch of brute force attempts triggering errors like
```
"../../../../../../../../../\\e\\t\\c/\\p\\a\\s\\s\\w\\d{{" is not a valid MIME type
```
And it's probably about time to put this in anyways. This is mostly just a copy-pasta of rack attacks basic config to get started with.