### PR TITLE
update redis-rails to redis-actionpack

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,8 +24,8 @@ gem "connection_pool"
 # gem "aws-sdk-s3", "~> 1"
 
 # Caching - Rails 5.2 shipped with a redis cache for fragments, but doesn't
-# provide session storage via redis too, which redis-rails does.
-gem "redis-rails"
+# provide session storage via redis too, which redis-actionpack does.
+gem "redis-actionpack"
 gem "redis-rack-cache"
 
 # CORS & other Security

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -288,7 +288,7 @@ GEM
     rack (2.2.2)
     rack-attack (6.2.2)
       rack (>= 1.0, < 3)
-    rack-cache (1.9.0)
+    rack-cache (1.11.1)
       rack (>= 0.4)
     rack-cors (1.0.5)
       rack (>= 1.6.0)
@@ -336,26 +336,19 @@ GEM
       execjs
       railties (>= 3.2)
       tilt
-    redis (4.1.2)
-    redis-actionpack (5.1.0)
-      actionpack (>= 4.0, < 7)
-      redis-rack (>= 1, < 3)
+    redis (4.1.4)
+    redis-actionpack (5.2.0)
+      actionpack (>= 5, < 7)
+      redis-rack (>= 2.1.0, < 3)
       redis-store (>= 1.1.0, < 2)
-    redis-activesupport (5.2.0)
-      activesupport (>= 3, < 7)
-      redis-store (>= 1.3, < 2)
-    redis-rack (2.0.5)
-      rack (>= 1.5, < 3)
+    redis-rack (2.1.2)
+      rack (>= 2.0.8, < 3)
       redis-store (>= 1.2, < 2)
-    redis-rack-cache (2.1.0)
-      rack-cache (>= 1.6, < 2)
+    redis-rack-cache (2.2.1)
+      rack-cache (>= 1.10, < 2)
       redis-store (>= 1.6, < 2)
-    redis-rails (5.0.2)
-      redis-actionpack (>= 5.0, < 6)
-      redis-activesupport (>= 5.0, < 6)
-      redis-store (>= 1.2, < 2)
-    redis-store (1.6.0)
-      redis (>= 2.2, < 5)
+    redis-store (1.8.2)
+      redis (>= 4, < 5)
     regexp_parser (1.6.0)
     rexml (3.2.4)
     rspec (3.8.0)
@@ -554,8 +547,8 @@ DEPENDENCIES
   rake
   react-rails
   redis
+  redis-actionpack
   redis-rack-cache
-  redis-rails
   rspec
   rspec-rails (~> 4.0.0.beta)
   rspec_api_documentation


### PR DESCRIPTION
Hopefully get sidekiq panel working again and aligns the gems with the current support (redis-rails is deprecated).