### PR TITLE
Bugfix relative/absolute and schemaless urls in the cacher

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -197,3 +197,6 @@ Style/HashTransformValues:
 Lint/MissingSuper:
   Exclude:
     - app/components/*
+
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: consistent_comma

--- a/app/components/flash_component.rb
+++ b/app/components/flash_component.rb
@@ -3,7 +3,7 @@
 class FlashComponent < ViewComponent::Base
   TYPES = {
     notice: "bg-denim-400",
-    alert: "bg-mango-700"
+    alert: "bg-mango-700",
   }.freeze
 
   attr_reader :message

--- a/app/components/tag_component.rb
+++ b/app/components/tag_component.rb
@@ -19,7 +19,7 @@ class TagComponent < ViewComponent::Base
       pink: :pink,
       brown: :brown,
       grey: :gray,
-      black: :gray
+      black: :gray,
     }.transform_keys(&:to_s).fetch tag.color, "limegreen"
   end
 end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -8,7 +8,7 @@ class DashboardController < ApplicationController
 
     @stats = {
       total_count: scope.count,
-      untagged_count: scope.left_joins(:tags).where(bookmarks_tags: { id: nil }).count
+      untagged_count: scope.left_joins(:tags).where(bookmarks_tags: { id: nil }).count,
     }
 
     @recent_bookmarks = scope.limit(5).page

--- a/app/jobs/import_data/pinboard_job.rb
+++ b/app/jobs/import_data/pinboard_job.rb
@@ -23,7 +23,7 @@ class ImportData::PinboardJob < ImportData::BaseJob
       {
         title: entry["description"],
         description: entry["extended"],
-        tags:
+        tags:,
       },
       created_at
     ]

--- a/app/jobs/import_data/pocket_job.rb
+++ b/app/jobs/import_data/pocket_job.rb
@@ -18,7 +18,7 @@ class ImportData::PocketJob < ImportData::BaseJob
       entry["href"],
       {
         title: entry.inner_text,
-        tags:
+        tags:,
       },
       created_at
     ]

--- a/app/models/import_data.rb
+++ b/app/models/import_data.rb
@@ -25,7 +25,7 @@ class ImportData < ApplicationRecord
 
   enum import_type: {
     pinboard: "pinboard",
-    pocket: "pocket"
+    pocket: "pocket",
   }
 
   after_create_commit :schedule_import

--- a/app/views/admin/bookmarks/cache/show.html.erb
+++ b/app/views/admin/bookmarks/cache/show.html.erb
@@ -8,6 +8,10 @@
       <%= link_to "Cache Details", "#", class: "tab active" %>
       <%= link_to "Edit", "#", class: "tab" %>
     <% end %>
+
+    <% c.actions do %>
+      <%= button_to "Recache", admin_bookmark_cache_index_path(@bookmark), class: "btn -tertiary" %>
+    <% end %>
   <% end %>
 
   <%= render Admin::BreadcrumbsComponent.new do |c| %>

--- a/app/views/admin/bookmarks/show.html.erb
+++ b/app/views/admin/bookmarks/show.html.erb
@@ -8,6 +8,10 @@
       <%= link_to "Cache Details", "#", class: "tab active" %>
       <%= link_to "Edit", "#", class: "tab" %>
     <% end %>
+
+    <% c.actions do %>
+      <%= button_to "Recache", admin_bookmark_cache_index_path(@bookmark), class: "btn -tertiary" %>
+    <% end %>
   <% end %>
 
   <%= render Admin::BreadcrumbsComponent.new do |c| %>
@@ -73,5 +77,3 @@
     <% end %>
   <% end %>
 <% end %>
-
-

--- a/lib/webpage_cache_service.rb
+++ b/lib/webpage_cache_service.rb
@@ -4,9 +4,10 @@ require "tempfile"
 
 class WebpageCacheService
   DEFAULT_HEADERS = {
-    user_agent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:57.0) Gecko/20100101 Firefox/57.0",
+    user_agent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:106.0) Gecko/20100101 Firefox/106.0",
     accept_language: "en-US,en;q=0.5",
-    accept: "text/html;q=0.9,*/*;q=0.8; charset=utf-8"
+    accept: "text/html;q=0.9,*/*;q=0.8; charset=utf-8",
+    accept_encoding: "gzip, deflate",
   }.freeze
 
   ASSET_XPATHS = [

--- a/lib/webpage_cache_service/cache.rb
+++ b/lib/webpage_cache_service/cache.rb
@@ -50,7 +50,7 @@ class WebpageCacheService
     private
 
     def cache_root
-      response, root_attachment = get uri: uri
+      _response, root_attachment = get uri: uri
       @root_attachment = root_attachment
 
       offline_cache.tap do |obj|
@@ -158,7 +158,7 @@ class WebpageCacheService
       {
         uri: response.uri.to_s,
         status_code: response.code,
-        headers: response.headers.to_h
+        headers: response.headers.to_h,
       }
     end
 

--- a/spec/controllers/admin/applications_controller_spec.rb
+++ b/spec/controllers/admin/applications_controller_spec.rb
@@ -33,13 +33,13 @@ RSpec.describe Admin::ApplicationsController, type: :controller do
     {
       name: "test",
       redirect_uri: "https://localhost.local",
-      official: false
+      official: false,
     }
   end
 
   let(:invalid_attributes) do
     {
-      redirect_uri: "non-absolute"
+      redirect_uri: "non-absolute",
     }
   end
 
@@ -50,7 +50,7 @@ RSpec.describe Admin::ApplicationsController, type: :controller do
   # Doorkeeper::ApplicationsController. Be sure to keep this updated too.
   let(:valid_session) do
     {
-      user_id: user.id
+      user_id: user.id,
     }
   end
 
@@ -83,7 +83,7 @@ RSpec.describe Admin::ApplicationsController, type: :controller do
       let(:new_attributes) do
         {
           name: "fred",
-          official: true
+          official: true,
         }
       end
 

--- a/spec/controllers/admin/roles_controller_spec.rb
+++ b/spec/controllers/admin/roles_controller_spec.rb
@@ -31,13 +31,13 @@ RSpec.describe Admin::RolesController, type: :controller do
   # adjust the attributes here as well.
   let(:valid_attributes) do
     {
-      name: "test"
+      name: "test",
     }
   end
 
   let(:invalid_attributes) do
     {
-      name: nil
+      name: nil,
     }
   end
 
@@ -48,7 +48,7 @@ RSpec.describe Admin::RolesController, type: :controller do
   # Admin::RolesController. Be sure to keep this updated too.
   let(:valid_session) do
     {
-      user_id: user.id
+      user_id: user.id,
     }
   end
 
@@ -112,7 +112,7 @@ RSpec.describe Admin::RolesController, type: :controller do
 
       let(:new_attributes) do
         {
-          name: updated_name
+          name: updated_name,
         }
       end
 

--- a/spec/controllers/csp_violation_report_controller_spec.rb
+++ b/spec/controllers/csp_violation_report_controller_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe CspViolationReportController, type: :controller do
   let(:valid_attributes) do
     {
-      "csp-violation": {}
+      "csp-violation": {},
     }
   end
 


### PR DESCRIPTION
Hacked around some issues in the Addressable gems parser where it treats relative and schemaless urls as the same, and use the #join() call to handle converting relative/absolute but hostless urls to a more correct base (might still suffer from the html `<base>` being a different url than what the page was served on though).