### PR TITLE
Small bugfixes around rendering binary roots in the cache preview

### DIFF
--- a/app/controllers/bookmarks/cache_controller.rb
+++ b/app/controllers/bookmarks/cache_controller.rb
@@ -16,7 +16,12 @@ class Bookmarks::CacheController < ApplicationController
     root_blob = @bookmark.current_offline_cache.root.blob
     return render :unavailable, status: :not_found unless root_blob.service.exist? root_blob.key
 
-    render html: renderer.render.html_safe
+    case renderer.render
+    in [:html, html]
+      render html: html.html_safe
+    in [:binary, content_type, data]
+      send_data data, type: content_type, disposition: "inline"
+    end
   end
   # rubocop:enable Rails/OutputSafety
 

--- a/lib/webpage_cache_service/cache.rb
+++ b/lib/webpage_cache_service/cache.rb
@@ -82,6 +82,7 @@ class WebpageCacheService
         .map(&:to_s)
         .uniq
         .compact
+        .reject { |link| link.start_with? "data:" }
         .map(&Addressable::URI.method(:parse))
         .map(&method(:derelative))
         .map(&:to_s)


### PR DESCRIPTION
Allows the renderer for offline caches/archives to handle binary files such as PDFs and images.

<img width="696" alt="image" src="https://user-images.githubusercontent.com/94542/194479521-b415fe8a-4cb5-49a6-af65-d4f9c07373e0.png">
